### PR TITLE
Set paintbrush tool as the default

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -51,7 +51,7 @@ export class UserInterface extends Component {
       },
       imageWidth: 0,
       imageHeight: 0,
-      activeTool: null,
+      activeTool: "paintbrush",
       activeAnnotationID: null,
 
       brushSize: 20,
@@ -60,6 +60,7 @@ export class UserInterface extends Component {
       minimapPositionAndSize: { top: 0, left: 450, width: 200, height: 200 },
     };
     this.updateImageDimensions = this.updateImageDimensions.bind(this);
+    this.annotationsObject.addAnnotation(this.state.activeTool)
   }
 
   setScaleAndPan = (scaleAndPan: {


### PR DESCRIPTION
# Description

In this PR we set the paintbrush tool as the default when the app loads. We created a default tool with the selected annotation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
