### PR TITLE
fix: Reuse empty annotation at change of active tool

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -63,6 +63,19 @@ export class Annotations {
     this.data[this.activeAnnotationID]["coordinates"] = newCoordinates;
   };
 
+  setActiveAnnotationToolbox = (newToolbox: string): void => {
+    this.data[this.activeAnnotationID].toolbox = newToolbox;
+  };
+
+  isActiveAnnotationEmpty = (): boolean => {
+    // Check whether the active annotation object contains any
+    // paintbrush or spline annotations.
+    return (
+      this.data[this.activeAnnotationID].coordinates.length === 0 &&
+      this.data[this.activeAnnotationID].brushStrokes.length === 0
+    );
+  };
+
   getAllAnnotations = (): AnnotationsDataArray => {
     return this.data;
   };

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -66,9 +66,7 @@ export class UserInterface extends Component {
   };
 
   annotationsObject: Annotations;
-
   theme: Theme;
-
   imageSource: string;
 
   constructor(props: never) {
@@ -172,22 +170,36 @@ export class UserInterface extends Component {
   selectSplineTool = (): void => {
     // Change active tool to spline.
     if (this.state.activeTool != Tools.spline) {
-      this.setState({ activeTool: Tools.spline });
+      this.setState({ activeTool: Tools.spline }, () => {
+        this.reuseEmptyAnnotation();
+      });
     }
   };
 
   selectPaintbrushTool = (): void => {
     // Change active tool to paintbrush.
     if (this.state.activeTool != Tools.paintbrush) {
-      this.setState({ activeTool: Tools.paintbrush });
+      this.setState({ activeTool: Tools.paintbrush }, () => {
+        this.reuseEmptyAnnotation();
+      });
     }
   };
 
   addAnnotation = (): void => {
-    this.annotationsObject.addAnnotation(this.state.activeTool);
+    this.annotationsObject.addAnnotation(Tools[this.state.activeTool]);
     this.setState({
       activeAnnotationID: this.annotationsObject.getActiveAnnotationID(),
     });
+  };
+
+  reuseEmptyAnnotation = (): void => {
+    /* If the active annotation object is empty, change the value of toolbox 
+    to match the active tool. */
+    if (this.annotationsObject.isActiveAnnotationEmpty()) {
+      this.annotationsObject.setActiveAnnotationToolbox(
+        Tools[this.state.activeTool]
+      );
+    }
   };
 
   handleToolboxChange = (panel: string) => (

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -1,6 +1,5 @@
 import React, { Component, ChangeEvent, ReactNode } from "react";
 
-
 import { Annotations } from "./annotation";
 
 import {
@@ -36,6 +35,12 @@ import { BackgroundCanvas, BackgroundMinimap } from "./toolboxes/background";
 import { SplineCanvas } from "./toolboxes/spline";
 import { PaintbrushCanvas } from "./toolboxes/paintbrush";
 
+// Define all mutually exclusive tools
+enum Tools {
+  paintbrush = "paintbrush",
+  spline = "spline",
+}
+
 export class UserInterface extends Component {
   state: {
     scaleAndPan: {
@@ -43,7 +48,7 @@ export class UserInterface extends Component {
       y: number;
       scale: number;
     };
-    activeTool?: "spline" | "paintbrush";
+    activeTool?: Tools;
     imageWidth: number;
     imageHeight: number;
     activeAnnotationID: number;
@@ -77,7 +82,7 @@ export class UserInterface extends Component {
       },
       imageWidth: 0,
       imageHeight: 0,
-      activeTool: "paintbrush",
+      activeTool: Tools.paintbrush,
       activeAnnotationID: null,
       brushSize: 20,
       viewportPositionAndSize: { top: 0, left: 0, width: 768, height: 768 },
@@ -90,8 +95,7 @@ export class UserInterface extends Component {
       },
     });
     this.imageSource = "public/zebrafish-heart.jpg";
-
-    this.annotationsObject.addAnnotation(this.state.activeTool);
+    this.annotationsObject.addAnnotation(Tools[this.state.activeTool]);
   }
 
   setViewportPositionAndSize = (viewportPositionAndSize: {
@@ -165,19 +169,17 @@ export class UserInterface extends Component {
     });
   };
 
-  toggleSpline = (): void => {
-    if (this.state.activeTool === "spline") {
-      this.setState({ activeTool: null });
-    } else {
-      this.setState({ activeTool: "spline" });
+  selectSplineTool = (): void => {
+    // Change active tool to spline.
+    if (this.state.activeTool != Tools.spline) {
+      this.setState({ activeTool: Tools.spline });
     }
   };
 
-  togglePaintbrush = (): void => {
-    if (this.state.activeTool === "paintbrush") {
-      this.setState({ activeTool: null });
-    } else {
-      this.setState({ activeTool: "paintbrush" });
+  selectPaintbrushTool = (): void => {
+    // Change active tool to paintbrush.
+    if (this.state.activeTool != Tools.paintbrush) {
+      this.setState({ activeTool: Tools.paintbrush });
     }
   };
 
@@ -223,7 +225,7 @@ export class UserInterface extends Component {
 
               <SplineCanvas
                 scaleAndPan={this.state.scaleAndPan}
-                isActive={this.state.activeTool === "spline"}
+                isActive={this.state.activeTool === Tools.spline}
                 annotationsObject={this.annotationsObject}
                 imageWidth={this.state.imageWidth}
                 imageHeight={this.state.imageHeight}
@@ -233,7 +235,7 @@ export class UserInterface extends Component {
 
               <PaintbrushCanvas
                 scaleAndPan={this.state.scaleAndPan}
-                isActive={this.state.activeTool === "paintbrush"}
+                isActive={this.state.activeTool === Tools.paintbrush}
                 annotationsObject={this.annotationsObject}
                 imageWidth={this.state.imageWidth}
                 imageHeight={this.state.imageHeight}
@@ -320,7 +322,7 @@ export class UserInterface extends Component {
                   <Tooltip title="Activate paintbrush">
                     <IconButton
                       id={"activate-paintbrush"}
-                      onClick={this.togglePaintbrush}
+                      onClick={this.selectPaintbrushTool}
                     >
                       <Brush />
                     </IconButton>
@@ -349,7 +351,7 @@ export class UserInterface extends Component {
                   <Tooltip title="Activate spline">
                     <IconButton
                       id={"activate-spline"}
-                      onClick={this.toggleSpline}
+                      onClick={this.selectSplineTool}
                     >
                       <Brush />
                     </IconButton>


### PR DESCRIPTION
# Description

Fixes the bug described in #35

closes #35

# Dependency changes

No

# Testing

N/A

# Documentation

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~New and existing unit tests pass locally with my changes~
