### PR TITLE
fix: remove Material errors

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -288,7 +288,7 @@ export class UserInterface extends Component {
               </div>
 
               <Grid container justify="center">
-                <ButtonGroup>
+                <div>
                   <Tooltip title="Zoom out">
                     <IconButton id={"zoom-out"} onClick={this.decrementScale}>
                       <ZoomOut />
@@ -304,32 +304,30 @@ export class UserInterface extends Component {
                       <ZoomIn />
                     </IconButton>
                   </Tooltip>
-                </ButtonGroup>
+                </div>
 
-                <ButtonGroup orientation="vertical">
+                <div>
                   <Tooltip title="Pan up">
                     <IconButton id={"pan-up"} onClick={this.incrementPanY}>
                       <KeyboardArrowUp />
                     </IconButton>
                   </Tooltip>
-                  <ButtonGroup>
-                    <Tooltip title="Pan left">
-                      <IconButton id={"pan-left"} onClick={this.incrementPanX}>
-                        <KeyboardArrowLeft />
-                      </IconButton>
-                    </Tooltip>
-                    <Tooltip title="Pan right">
-                      <IconButton id={"pan-right"} onClick={this.decrementPanX}>
-                        <KeyboardArrowRight />
-                      </IconButton>
-                    </Tooltip>
-                  </ButtonGroup>
+                  <Tooltip title="Pan left">
+                    <IconButton id={"pan-left"} onClick={this.incrementPanX}>
+                      <KeyboardArrowLeft />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Pan right">
+                    <IconButton id={"pan-right"} onClick={this.decrementPanX}>
+                      <KeyboardArrowRight />
+                    </IconButton>
+                  </Tooltip>
                   <Tooltip title="Pan down">
                     <IconButton id={"pan-down"} onClick={this.decrementPanY}>
                       <KeyboardArrowDown />
                     </IconButton>
                   </Tooltip>
-                </ButtonGroup>
+                </div>
               </Grid>
 
               <Accordion

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -8,6 +8,7 @@ import {
   Toolbar,
   Tooltip,
   IconButton,
+  Button,
   ButtonGroup,
   Grid,
   Accordion,
@@ -367,46 +368,48 @@ export class UserInterface extends Component {
               </div>
 
               <Grid container justify="center">
-                <div>
+                <ButtonGroup size="small" style={{ margin: "5px" }}>
                   <Tooltip title="Zoom out">
-                    <IconButton id={"zoom-out"} onClick={this.decrementScale}>
+                    <Button id={"zoom-out"} onClick={this.decrementScale}>
                       <ZoomOut />
-                    </IconButton>
+                    </Button>
                   </Tooltip>
                   <Tooltip title="Reset zoom and pan">
-                    <IconButton id={"reset"} onClick={this.resetScaleAndPan}>
+                    <Button id={"reset"} onClick={this.resetScaleAndPan}>
                       <AspectRatio />
-                    </IconButton>
+                    </Button>
                   </Tooltip>
                   <Tooltip title="Zoom in">
-                    <IconButton id={"zoom-in"} onClick={this.incrementScale}>
+                    <Button id={"zoom-in"} onClick={this.incrementScale}>
                       <ZoomIn />
-                    </IconButton>
+                    </Button>
                   </Tooltip>
-                </div>
+                </ButtonGroup>
 
-                <div>
+                <ButtonGroup size="small" style={{ marginBottom: "5px" }}>
                   <Tooltip title="Pan up">
-                    <IconButton id={"pan-up"} onClick={this.incrementPanY}>
+                    <Button id={"pan-up"} onClick={this.incrementPanY}>
                       <KeyboardArrowUp />
-                    </IconButton>
+                    </Button>
                   </Tooltip>
-                  <Tooltip title="Pan left">
-                    <IconButton id={"pan-left"} onClick={this.incrementPanX}>
-                      <KeyboardArrowLeft />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip title="Pan right">
-                    <IconButton id={"pan-right"} onClick={this.decrementPanX}>
-                      <KeyboardArrowRight />
-                    </IconButton>
-                  </Tooltip>
+                  <ButtonGroup size="small">
+                    <Tooltip title="Pan left">
+                      <Button id={"pan-left"} onClick={this.incrementPanX}>
+                        <KeyboardArrowLeft />
+                      </Button>
+                    </Tooltip>
+                    <Tooltip title="Pan right">
+                      <Button id={"pan-right"} onClick={this.decrementPanX}>
+                        <KeyboardArrowRight />
+                      </Button>
+                    </Tooltip>
+                  </ButtonGroup>
                   <Tooltip title="Pan down">
-                    <IconButton id={"pan-down"} onClick={this.decrementPanY}>
+                    <Button id={"pan-down"} onClick={this.decrementPanY}>
                       <KeyboardArrowDown />
-                    </IconButton>
+                    </Button>
                   </Tooltip>
-                </div>
+                </ButtonGroup>
               </Grid>
 
               <Accordion


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3502798/112197225-c0100d00-8c03-11eb-98d0-e4097ce297c2.png)

This is caused by IconButtons being used in a ButtonGroup which is invalid as noted [here](https://github.com/mui-org/material-ui/issues/16156#issuecomment-500853073)

This removes then and just wraps in a div.

I'll add in proper styling when we start with a style sheet etc