### PR TITLE
fix: Labels re-render at change of active annotation

### DIFF
--- a/src/components/Labels.tsx
+++ b/src/components/Labels.tsx
@@ -26,12 +26,14 @@ import { Annotations } from "../annotation";
 interface Props {
   annotationObject: Annotations;
   presetLabels: string[];
+  activeAnnotationID: number;
   theme: Theme;
 }
 
 export const Labels: FunctionComponent<Props> = ({
   annotationObject,
   presetLabels,
+  activeAnnotationID,
   theme,
 }): ReactElement => {
   const getMenuLabels = (): string[] => {
@@ -50,11 +52,6 @@ export const Labels: FunctionComponent<Props> = ({
     setAssignedLabels(annotationObject.getLabels());
   };
 
-  useEffect(() => {
-    // Update menuLabels after assignedLabels has been reset.
-    setMenuLabels(getMenuLabels());
-  });
-
   const handleClick = () => {
     setIsOpen(!isOpen);
   };
@@ -64,6 +61,16 @@ export const Labels: FunctionComponent<Props> = ({
   );
   const [menuLabels, setMenuLabels] = useState(getMenuLabels());
   const [isOpen, setIsOpen] = React.useState(false);
+
+  useEffect(() => {
+    // Re-render assigned labels at change of active annotation ID.
+    setAssignedLabels(annotationObject.getLabels());
+  }, [activeAnnotationID]);
+
+  useEffect(() => {
+    // Re-render menu labels at change of assigned labels.
+    setMenuLabels(getMenuLabels());
+  });
 
   return (
     <List style={{ width: "100%" }}>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -91,7 +91,7 @@ export class UserInterface extends Component {
       imageWidth: 0,
       imageHeight: 0,
       activeTool: Tools.paintbrush,
-      activeAnnotationID: null,
+      activeAnnotationID: 0,
       brushSize: 20,
       viewportPositionAndSize: { top: 0, left: 0, width: 768, height: 768 },
       expanded: false,
@@ -521,6 +521,7 @@ export class UserInterface extends Component {
                   <Labels
                     annotationObject={this.annotationsObject}
                     presetLabels={this.presetLabels}
+                    activeAnnotationID={this.state.activeAnnotationID}
                     theme={this.theme}
                   />
                 </AccordionDetails>


### PR DESCRIPTION
# Description

Fixes bug: labels don't re-render at change of active annotation.

# Dependency changes

No

# Testing

N/A

# Documentation

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
