### PR TITLE
Add namespacing to keybinds

### DIFF
--- a/src/keybindings/index.ts
+++ b/src/keybindings/index.ts
@@ -13,7 +13,8 @@ const keydownListener = (
   if (event.altKey) code = `alt+${code}`;
 
   if (keybindingsMap[code]) {
-    document.dispatchEvent(new Event(keybindingsMap[code]));
+    const [namespace, method] = keybindingsMap[code].split(".");
+    document.dispatchEvent(new CustomEvent(method, { detail: namespace }));
   }
 };
 

--- a/src/keybindings/keybindings.spec.ts
+++ b/src/keybindings/keybindings.spec.ts
@@ -1,13 +1,23 @@
 import { keydownListener } from "./index";
 
 const bindings = {
-  keyA: "Only A",
-  "ctrl+keyA": "Ctrl + A",
-  "ctrl+shift+keyA": "Ctrl + Shift + A",
+  keyA: "test.Only A",
+  "ctrl+keyA": "test.Ctrl + A",
+  "ctrl+shift+keyA": "test.Ctrl + Shift + A",
 };
 
 test("Handles standard keys", (done: any) => {
   document.addEventListener("Only A", () => done());
+
+  const event = new KeyboardEvent("keypress", { code: "keyA" });
+  keydownListener(event, bindings);
+});
+
+test("Handles Namespacing", (done: any) => {
+  document.addEventListener("Only A", (e: CustomEvent) => {
+    expect(e.detail).toEqual("test");
+    done();
+  });
 
   const event = new KeyboardEvent("keypress", { code: "keyA" });
   keydownListener(event, bindings);

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -5,9 +5,9 @@
 // eg alt+shift+KeyA
 
 export const keybindings = {
-  Backspace: "deleteSelectedPoint",
-  Enter: "changeSplineModeToEdit",
-  Escape: "deselectPoint",
+  Backspace: "spline.deleteSelectedPoint",
+  Enter: "spline.changeSplineModeToEdit",
+  Escape: "spline.deselectPoint",
 } as Readonly<{
   [key: string]: string;
 }>;

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -16,7 +16,16 @@ interface Props extends CanvasProps {
   theme: Theme;
 }
 
+// Here we define the methods that are exposed to be called by keyboard shortcuts
+// We should maybe namespace them so we don't get conflicting methods across toolboxes.
+export const events = [] as const;
+
+interface Event extends CustomEvent {
+  type: typeof events[number];
+}
+
 export class PaintbrushCanvas extends Component<Props> {
+  readonly name = "paintbrush";
   private baseCanvas: BaseCanvas;
   private drawingCanvas: BaseCanvas;
   private isPressing: boolean;
@@ -210,19 +219,7 @@ export class PaintbrushCanvas extends Component<Props> {
     this.drawAllStrokes();
   };
 
-  componentDidUpdate(): void {
-    // Redraw if we change pan or zoom
-    const activeAnnotation = this.props.annotationsObject.getActiveAnnotation();
-
-    if (activeAnnotation?.brushStrokes.length > 0) {
-      //this.drawSplineVector(activeAnnotation.coordinates);
-      //repaint
-      this.drawAllStrokes();
-    }
-  }
-
   getCursor = () => {
-    console.log(this.props.brushType);
     if (this.props.brushType == "paintbrush") {
       return "crosshair";
     } else if (this.props.brushType == "eraser") {
@@ -230,16 +227,43 @@ export class PaintbrushCanvas extends Component<Props> {
     }
     return "none";
   };
-  //
+
+  handleEvent = (event: Event): void => {
+    if (event.detail === this.name) {
+      // @ts-ignore (This is needed if there's no keybindings!)
+      this[event.type]?.call(this);
+    }
+  };
+
+  componentDidMount(): void {
+    for (const event of events) {
+      document.addEventListener(event, this.handleEvent);
+    }
+  }
+
+  componentWillUnmount(): void {
+    for (const event of events) {
+      document.removeEventListener(event, this.handleEvent);
+    }
+  }
+
+  componentDidUpdate(): void {
+    // Redraw if we change pan or zoom
+    const activeAnnotation = this.props.annotationsObject.getActiveAnnotation();
+
+    if (activeAnnotation?.brushStrokes.length > 0) {
+      this.drawAllStrokes();
+    }
+  }
+
   render = (): ReactNode => {
     return (
       //We have two canvases in order to be able to erase stuff.
-
       <div
         style={{
           pointerEvents:
-            this.props.brushType == "paintbrush" ||
-            this.props.brushType == "eraser"
+            this.props.brushType === "paintbrush" ||
+            this.props.brushType === "eraser"
               ? "auto"
               : "none",
         }}

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -26,12 +26,13 @@ export const events = [
   "changeSplineModeToEdit",
   "deselectPoint",
 ] as const;
+
 interface Event extends CustomEvent {
   type: typeof events[number];
 }
 
 export class SplineCanvas extends Component<Props> {
-  readonly name: "spline";
+  readonly name = "spline";
 
   private baseCanvas: BaseCanvas;
   private selectedPointIndex: number;
@@ -413,9 +414,8 @@ export class SplineCanvas extends Component<Props> {
   }
 
   handleEvent = (event: Event): void => {
-    const method = event.type;
-    if (this[method]) {
-      this[method].call(this);
+    if (event.detail === this.name) {
+      this[event.type]?.call(this);
     }
   };
 

--- a/src/toolboxes/spline/index.ts
+++ b/src/toolboxes/spline/index.ts
@@ -1,1 +1,1 @@
-export { SplineCanvas } from "./Canvas";
+export { SplineCanvas, events } from "./Canvas";

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -142,6 +142,7 @@ export class UserInterface extends Component {
       this.state.viewportPositionAndSize.width / this.state.imageWidth,
       this.state.viewportPositionAndSize.height / this.state.imageHeight
     );
+
     let xMargin =
       this.state.imageWidth *
         imageScalingFactor *


### PR DESCRIPTION
I've added a readonly `name` field to the canvases that currently have shortcuts.

Events can then be filtered to check if they are aimed at this canvas (https://github.com/gliff-ai/annotate/pull/64/files#diff-94f3880be2d1abd06d206719935522d35557921fce534b4b9e79412c68e9ec95R417)

(It's not the optimal way, but it's the best way I could do that keeps TS happy!)