### PR TITLE
feat: cycling annotations with ctrl+arrowkeys

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -64,6 +64,10 @@ export class Annotations {
     return this.data.length;
   };
 
+  setActiveAnnotationID = (id: number): void => {
+    this.activeAnnotationID = id;
+  };
+
   setAnnotationCoordinates = (newCoordinates: XYPoint[]): void => {
     this.data[this.activeAnnotationID]["coordinates"] = newCoordinates;
   };

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -9,8 +9,8 @@ export const keybindings = {
   Enter: "spline.changeSplineModeToEdit",
   Escape: "spline.deselectPoint",
   "ctrl+KeyC": "spline.closeLoop",
-  "ctrl+ArrowLeft": "ui.nextAnnotation",
-  "ctrl+ArrowRight": "ui.previousAnnotation",
+  "ctrl+ArrowLeft": "ui.previousAnnotation",
+  "ctrl+ArrowRight": "ui.nextAnnotation",
 } as Readonly<{
   [key: string]: string;
 }>;

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -8,6 +8,9 @@ export const keybindings = {
   Backspace: "spline.deleteSelectedPoint",
   Enter: "spline.changeSplineModeToEdit",
   Escape: "spline.deselectPoint",
+  "ctrl+KeyC": "spline.closeLoop",
+  "ctrl+ArrowLeft": "ui.nextAnnotation",
+  "ctrl+ArrowRight": "ui.previousAnnotation",
 } as Readonly<{
   [key: string]: string;
 }>;

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -25,6 +25,7 @@ export const events = [
   "deleteSelectedPoint",
   "changeSplineModeToEdit",
   "deselectPoint",
+  "closeLoop",
 ] as const;
 
 interface Event extends CustomEvent {
@@ -291,7 +292,7 @@ export class SplineCanvas extends Component<Props> {
     coordinates[index] = { x: newX, y: newY };
   };
 
-  onDoubleClick = (): void => {
+  closeLoop = (): void => {
     // Append the first spline point to the end, making a closed polygon
 
     const currentSplineVector = this.props.annotationsObject.getActiveAnnotation()
@@ -436,7 +437,6 @@ export class SplineCanvas extends Component<Props> {
       <div style={{ pointerEvents: this.props.isActive ? "auto" : "none" }}>
         <BaseCanvas
           onClick={this.onClick}
-          onDoubleClick={this.onDoubleClick}
           onMouseDown={this.onMouseDown}
           onMouseMove={this.onMouseMove}
           onMouseUp={this.onMouseUp}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -50,6 +50,14 @@ enum Tools {
   eraser = "eraser",
 }
 
+interface Event extends CustomEvent {
+  type: typeof events[number];
+}
+
+// Here we define the methods that are exposed to be called by keyboard shortcuts
+// We should maybe namespace them so we don't get conflicting methods across toolboxes.
+export const events = ["nextAnnotation", "previousAnnotation"] as const;
+
 export class UserInterface extends Component {
   state: {
     scaleAndPan: {
@@ -117,6 +125,12 @@ export class UserInterface extends Component {
     this.annotationsObject.addAnnotation(Tools[this.state.activeTool]);
     this.presetLabels = ["label-1", "label-2", "label-3"]; //TODO: find a place for this
   }
+
+  handleEvent = (event: Event): void => {
+    if (event.detail == "ui") {
+      this[event.type]?.call(this);
+    }
+  };
 
   setViewportPositionAndSize = (viewportPositionAndSize: {
     top?: number;
@@ -289,6 +303,31 @@ export class UserInterface extends Component {
     });
   };
 
+  nextAnnotation = (): void => {
+    this.cycleActiveAnnotation(true);
+  };
+
+  previousAnnotation = (): void => {
+    this.cycleActiveAnnotation(false);
+  };
+
+  cycleActiveAnnotation = (forward: boolean = true): void => {
+    const data = this.annotationsObject.getAllAnnotations();
+    let i = this.state.activeAnnotationID;
+    let inc = forward ? 1 : -1;
+
+    // cycle i forward or backward until we reach another annotation whose toolbox attribute matches the current activeTool:
+    do {
+      // increment or decrement i by 1, wrapping around if we go above the length of the array(-1) or below 0:
+      i =
+        (i + inc + this.annotationsObject.length()) %
+        this.annotationsObject.length();
+    } while (data[i].toolbox !== Tools[this.state.activeTool]);
+
+    this.annotationsObject.setActiveAnnotationID(i);
+    this.setState({ activeAnnotationID: i });
+  };
+
   reuseEmptyAnnotation = (): void => {
     /* If the active annotation object is empty, change the value of toolbox
     to match the active tool. */
@@ -315,7 +354,16 @@ export class UserInterface extends Component {
 
   componentDidMount = (): void => {
     document.addEventListener("keydown", keydownListener);
+    for (const event of events) {
+      document.addEventListener(event, this.handleEvent);
+    }
   };
+
+  componentWillUnmount(): void {
+    for (const event of events) {
+      document.removeEventListener(event, this.handleEvent);
+    }
+  }
 
   render = (): ReactNode => {
     return (


### PR DESCRIPTION
# Description

Added event handlers in ui.tsx for cycling forwards and backwards through annotations (i.e. changing the activeAnnotationID in the annotations object, and passing this information down to the components that need it). Set up the keymappings in keybindings.ts; ctrl+rightarrow goes forward, ctrl+leftarrow goes back.

Also replaced doubleclick to close splines with a keyboard shortcut (ctrl+c).

closes #24 #47


# Dependency changes

N/A

# Testing

N/A

# Documentation

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
