### PR TITLE
feat: Use state store for Toolboxes

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,4 @@
 // Based on https://github.com/pie6k/hooksy
-
 import { useState, useCallback, useLayoutEffect } from "react";
 
 interface StoreListeningComponentData<T> {
@@ -45,10 +44,10 @@ export function createStore<T>(
     storeState = newStoreState;
 
     storeListeningComponents.forEach(({ update, options }) => {
-      const shouldUpdate =
-        !options ||
-        !options.shouldUpdate ||
-        !options.shouldUpdate(oldStoreState, newStoreState);
+      const shouldUpdate = options?.shouldUpdate?.(
+        oldStoreState,
+        newStoreState
+      );
 
       if (!shouldUpdate) {
         return;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,6 +11,8 @@ export interface UseStoreStateOptions<T> {
   shouldUpdate?: (oldState: T, newState: T) => boolean;
 }
 
+type UpdateState<T> = readonly [T, (newStoreState: T) => void];
+
 function useForceUpdate(): () => void {
   const [, updateComponent] = useState<Record<string, unknown>>({});
 
@@ -32,9 +34,7 @@ function removeArrayElement<T>(arr: T[], elem: T): void {
 export function createStore<T>(
   defaultValue: T
 ): readonly [
-  (
-    options?: UseStoreStateOptions<T>
-  ) => readonly [T, (newStoreState: T) => void],
+  (options?: UseStoreStateOptions<T>) => UpdateState<T>,
   (newStoreState: T) => void
 ] {
   let storeState = defaultValue;
@@ -58,9 +58,7 @@ export function createStore<T>(
     });
   }
 
-  function useStoreState(
-    options?: UseStoreStateOptions<T>
-  ): readonly [T, (newStoreState: T) => void] {
+  function useStoreState(options?: UseStoreStateOptions<T>): UpdateState<T> {
     const forceUpdate = useForceUpdate();
 
     useLayoutEffect(() => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,74 @@
+// Based on https://github.com/pie6k/hooksy
+
+import { useState, useCallback, useLayoutEffect } from "react";
+
+interface StoreListeningComponentData<T> {
+  update: () => void;
+  options?: UseStoreStateOptions<T>;
+}
+
+export interface UseStoreStateOptions<T> {
+  shouldUpdate?: (oldState: T, newState: T) => boolean;
+}
+
+function useForceUpdate(): () => void {
+  const [, updateComponent] = useState<Record<string, unknown>>({});
+
+  return useCallback(() => {
+    updateComponent({});
+  }, []);
+}
+
+function removeArrayElement<T>(arr: T[], elem: T): void {
+  const index = arr.indexOf(elem);
+
+  if (index === -1) {
+    return;
+  }
+
+  arr.splice(index, 1);
+}
+
+export function createStore<T>(defaultValue: T) {
+  let storeState = defaultValue;
+  const storeListeningComponents: StoreListeningComponentData<T>[] = [];
+
+  function updateStoreState(newStoreState: T): void {
+    const oldStoreState = storeState;
+    storeState = newStoreState;
+
+    storeListeningComponents.forEach(({ update, options }) => {
+      const shouldUpdate =
+        !options ||
+        !options.shouldUpdate ||
+        !options.shouldUpdate(oldStoreState, newStoreState);
+
+      if (!shouldUpdate) {
+        return;
+      }
+
+      update();
+    });
+  }
+
+  function useStoreState(options?: UseStoreStateOptions<T>) {
+    const forceUpdate = useForceUpdate();
+
+    useLayoutEffect(() => {
+      const listeningData: StoreListeningComponentData<T> = {
+        options,
+        update: forceUpdate,
+      };
+
+      storeListeningComponents.push(listeningData);
+
+      return () => {
+        removeArrayElement(storeListeningComponents, listeningData);
+      };
+    });
+
+    return [storeState, updateStoreState] as const;
+  }
+
+  return [useStoreState, updateStoreState] as const;
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,4 +1,7 @@
-// Based on https://github.com/pie6k/hooksy
+/*
+This work was modified from https://github.com/pie6k/hooksy, which is released under MIT license by Adam Pietrasiak
+ */
+
 import { useState, useCallback, useLayoutEffect } from "react";
 
 interface StoreListeningComponentData<T> {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -29,7 +29,14 @@ function removeArrayElement<T>(arr: T[], elem: T): void {
   arr.splice(index, 1);
 }
 
-export function createStore<T>(defaultValue: T) {
+export function createStore<T>(
+  defaultValue: T
+): readonly [
+  (
+    options?: UseStoreStateOptions<T>
+  ) => readonly [T, (newStoreState: T) => void],
+  (newStoreState: T) => void
+] {
   let storeState = defaultValue;
   const storeListeningComponents: StoreListeningComponentData<T>[] = [];
 
@@ -51,7 +58,9 @@ export function createStore<T>(defaultValue: T) {
     });
   }
 
-  function useStoreState(options?: UseStoreStateOptions<T>) {
+  function useStoreState(
+    options?: UseStoreStateOptions<T>
+  ): readonly [T, (newStoreState: T) => void] {
     const forceUpdate = useForceUpdate();
 
     useLayoutEffect(() => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -44,10 +44,8 @@ export function createStore<T>(
     storeState = newStoreState;
 
     storeListeningComponents.forEach(({ update, options }) => {
-      const shouldUpdate = options?.shouldUpdate?.(
-        oldStoreState,
-        newStoreState
-      );
+      const shouldUpdate =
+        options?.shouldUpdate?.(oldStoreState, newStoreState) !== false;
 
       if (!shouldUpdate) {
         return;

--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -3,6 +3,8 @@ import React, { Component, ReactNode } from "react";
 import { BaseCanvas, CanvasProps as BaseProps } from "@/baseCanvas";
 import drawImageOnCanvas from "./drawImage";
 
+import { useBackgroundStore } from "./Store";
+
 interface Props extends BaseProps {
   imgSrc?: string;
   updateImageDimensions: (imageWidth: number, imageHeight: number) => void;
@@ -10,7 +12,7 @@ interface Props extends BaseProps {
   brightness: number;
 }
 
-export class BackgroundCanvas extends Component<Props> {
+export class BackgroundCanvasClass extends Component<Props> {
   private baseCanvas: BaseCanvas;
 
   private image: HTMLImageElement;
@@ -65,3 +67,20 @@ export class BackgroundCanvas extends Component<Props> {
     />
   );
 }
+
+export const BackgroundCanvas = (
+  props: Omit<Props, "contrast" | "brightness">
+) => {
+  const [background] = useBackgroundStore();
+
+  return (
+    <BackgroundCanvasClass
+      imgSrc={props.imgSrc}
+      updateImageDimensions={props.updateImageDimensions}
+      contrast={background.contrast}
+      brightness={background.brightness}
+      scaleAndPan={props.scaleAndPan}
+      canvasPositionAndSize={props.canvasPositionAndSize}
+    />
+  );
+};

--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from "react";
+import React, { Component, ReactNode, ReactElement } from "react";
 
 import { BaseCanvas, CanvasProps as BaseProps } from "@/baseCanvas";
 import drawImageOnCanvas from "./drawImage";
@@ -70,7 +70,7 @@ export class BackgroundCanvasClass extends Component<Props> {
 
 export const BackgroundCanvas = (
   props: Omit<Props, "contrast" | "brightness">
-) => {
+): ReactElement => {
   const [background] = useBackgroundStore();
 
   return (

--- a/src/toolboxes/background/Minimap.tsx
+++ b/src/toolboxes/background/Minimap.tsx
@@ -1,7 +1,8 @@
 import React, { Component, ReactNode } from "react";
 
-import { BaseMinimap, MinimapProps as BaseProps } from "../../baseCanvas";
+import { BaseMinimap, MinimapProps as BaseProps } from "@/baseCanvas";
 import drawImageOnCanvas from "./drawImage";
+import { useBackgroundStore } from "./Store";
 
 interface Props extends BaseProps {
   imgSrc?: string;
@@ -14,7 +15,8 @@ interface Props extends BaseProps {
   contrast: number;
   brightness: number;
 }
-export class BackgroundMinimap extends Component<Props> {
+
+export class BackgroundMinimapClass extends Component<Props> {
   private baseMinimap: BaseMinimap;
 
   private image: HTMLImageElement;
@@ -70,3 +72,23 @@ export class BackgroundMinimap extends Component<Props> {
     />
   );
 }
+
+export const BackgroundMinimap = (
+  props: Omit<Props, "contrast" | "brightness">
+) => {
+  const [background] = useBackgroundStore();
+
+  return (
+    <BackgroundMinimapClass
+      contrast={background.contrast}
+      brightness={background.brightness}
+      imgSrc={props.imgSrc}
+      imageWidth={props.imageWidth}
+      imageHeight={props.imageHeight}
+      canvasPositionAndSize={props.canvasPositionAndSize}
+      minimapPositionAndSize={props.minimapPositionAndSize}
+      setScaleAndPan={props.setScaleAndPan}
+      scaleAndPan={props.scaleAndPan}
+    />
+  );
+};

--- a/src/toolboxes/background/Minimap.tsx
+++ b/src/toolboxes/background/Minimap.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ReactNode } from "react";
+import React, { Component, ReactNode, ReactElement } from "react";
 
 import { BaseMinimap, MinimapProps as BaseProps } from "@/baseCanvas";
 import drawImageOnCanvas from "./drawImage";
@@ -75,7 +75,7 @@ export class BackgroundMinimapClass extends Component<Props> {
 
 export const BackgroundMinimap = (
   props: Omit<Props, "contrast" | "brightness">
-) => {
+): ReactElement => {
   const [background] = useBackgroundStore();
 
   return (

--- a/src/toolboxes/background/Store.ts
+++ b/src/toolboxes/background/Store.ts
@@ -1,0 +1,15 @@
+import { createStore } from "@/store";
+import { SLIDER_CONFIG, Sliders } from "./configSlider";
+
+interface BackgroundData {
+  contrast: number;
+  brightness: number;
+}
+
+const defaultBackground: BackgroundData = {
+  brightness: SLIDER_CONFIG[Sliders.brightness].initial,
+  contrast: SLIDER_CONFIG[Sliders.contrast].initial,
+};
+
+// we've created store with initial value. This can now be used anywhere and will share the value.
+export const [useBackgroundStore] = createStore(defaultBackground);

--- a/src/toolboxes/background/UI.tsx
+++ b/src/toolboxes/background/UI.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, ReactElement } from "react";
 import {
   Grid,
   Accordion,
@@ -19,7 +19,7 @@ interface Props {
   onChange: (event: ChangeEvent, isExpanded: boolean) => void;
 }
 
-const BackgroundUI = (props: Props) => {
+const BackgroundUI = (props: Props): ReactElement => {
   const [background, setBackground] = useBackgroundStore();
 
   function changeContrast(e: ChangeEvent, value: number) {

--- a/src/toolboxes/background/UI.tsx
+++ b/src/toolboxes/background/UI.tsx
@@ -1,0 +1,58 @@
+import React, { ChangeEvent } from "react";
+import {
+  Grid,
+  Accordion,
+  AccordionSummary,
+  Typography,
+  AccordionDetails,
+} from "@material-ui/core";
+
+import { ExpandMore } from "@material-ui/icons";
+
+import { BaseSlider } from "@/components/BaseSlider";
+import { Sliders, SLIDER_CONFIG } from "./configSlider";
+
+import { useBackgroundStore } from "./Store";
+
+interface Props {
+  expanded: boolean;
+  onChange: (event: ChangeEvent, isExpanded: boolean) => void;
+}
+
+const BackgroundUI = (props: Props) => {
+  const [background, setBackground] = useBackgroundStore();
+
+  function changeContrast(e: ChangeEvent, value: number) {
+    setBackground({ contrast: value, brightness: background.brightness });
+  }
+
+  function changeBrightness(e: ChangeEvent, value: number) {
+    setBackground({ brightness: value, contrast: background.contrast });
+  }
+
+  return (
+    <Accordion expanded={props.expanded} onChange={props.onChange}>
+      <AccordionSummary expandIcon={<ExpandMore />} id="background-toolbox">
+        <Typography>Background</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Grid container spacing={0} justify="center" wrap="nowrap">
+          <Grid item style={{ width: "85%", position: "relative" }}>
+            <BaseSlider
+              value={background.contrast}
+              config={SLIDER_CONFIG[Sliders.contrast]}
+              onChange={() => changeContrast}
+            />
+            <BaseSlider
+              value={background.brightness}
+              config={SLIDER_CONFIG[Sliders.brightness]}
+              onChange={() => changeBrightness}
+            />
+          </Grid>
+        </Grid>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export { BackgroundUI };

--- a/src/toolboxes/background/configSlider.ts
+++ b/src/toolboxes/background/configSlider.ts
@@ -1,4 +1,4 @@
-import { Config } from "./components/BaseSlider";
+import { Config } from "@/components/BaseSlider";
 
 export enum Sliders {
   contrast,

--- a/src/toolboxes/background/index.ts
+++ b/src/toolboxes/background/index.ts
@@ -1,2 +1,3 @@
 export { BackgroundCanvas } from "./Canvas";
 export { BackgroundMinimap } from "./Minimap";
+export { BackgroundUI } from "./UI";

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, Component } from "react";
+import React, { ReactNode, Component, ReactElement } from "react";
 
 import { BaseCanvas, CanvasProps } from "@/baseCanvas";
 import { Annotations } from "@/annotation";
@@ -303,7 +303,9 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
   );
 }
 
-export const PaintbrushCanvas = (props: Omit<Props, "brushRadius">) => {
+export const PaintbrushCanvas = (
+  props: Omit<Props, "brushRadius">
+): ReactElement => {
   const [paintbrush] = usePaintbrushStore();
 
   return (

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -6,6 +6,8 @@ import { canvasToImage, imageToCanvas } from "@/transforms";
 import { XYPoint } from "@/annotation/interfaces";
 import { theme } from "@/theme";
 
+import { usePaintbrushStore } from "./Store";
+
 interface Props extends CanvasProps {
   brushType: string;
   annotationsObject: Annotations;
@@ -28,7 +30,7 @@ interface Event extends CustomEvent {
 
 type Cursor = "crosshair" | "none" | "not-allowed";
 
-export class PaintbrushCanvas extends Component<Props, State> {
+export class PaintbrushCanvasClass extends Component<Props, State> {
   readonly name = "paintbrush";
 
   private baseCanvas: BaseCanvas;
@@ -300,3 +302,19 @@ export class PaintbrushCanvas extends Component<Props, State> {
     </div>
   );
 }
+
+export const PaintbrushCanvas = (props: Omit<Props, "brushRadius">) => {
+  const [paintbrush] = usePaintbrushStore();
+
+  return (
+    <PaintbrushCanvasClass
+      brushType={props.brushType}
+      annotationsObject={props.annotationsObject}
+      imageWidth={props.imageWidth}
+      imageHeight={props.imageHeight}
+      scaleAndPan={props.scaleAndPan}
+      canvasPositionAndSize={props.canvasPositionAndSize}
+      brushRadius={paintbrush.brushRadius}
+    />
+  );
+};

--- a/src/toolboxes/paintbrush/Store.ts
+++ b/src/toolboxes/paintbrush/Store.ts
@@ -1,0 +1,10 @@
+import { createStore } from "@/store";
+
+interface PaintbrushData {
+  brushRadius: number;
+}
+
+const defaultPaintbrush: PaintbrushData = { brushRadius: 10 };
+
+// we've created store with initial value. This can now be used anywhere and will share the value.
+export const [usePaintbrushStore] = createStore(defaultPaintbrush);

--- a/src/toolboxes/paintbrush/UI.tsx
+++ b/src/toolboxes/paintbrush/UI.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, Component, ChangeEvent } from "react";
+import React, { ChangeEvent } from "react";
 import {
   Tooltip,
   IconButton,

--- a/src/toolboxes/paintbrush/UI.tsx
+++ b/src/toolboxes/paintbrush/UI.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, ReactElement } from "react";
 import {
   Tooltip,
   IconButton,
@@ -26,7 +26,7 @@ interface Props {
   activateTool: (tool: Tool) => void;
 }
 
-const PaintbrushUI = (props: Props) => {
+const PaintbrushUI = (props: Props): ReactElement => {
   const [paintbrush, setPaintbrush] = usePaintbrushStore();
 
   function incrementBrush() {

--- a/src/toolboxes/paintbrush/UI.tsx
+++ b/src/toolboxes/paintbrush/UI.tsx
@@ -15,9 +15,9 @@ import {
   RadioButtonUncheckedSharp,
 } from "@material-ui/icons";
 
-import { usePaintbrushStore } from "./Store";
+import { Tool } from "@/tools";
 
-type Tool = "paintbrush" | "eraser";
+import { usePaintbrushStore } from "./Store";
 
 interface Props {
   expanded: boolean;

--- a/src/toolboxes/paintbrush/UI.tsx
+++ b/src/toolboxes/paintbrush/UI.tsx
@@ -1,0 +1,71 @@
+import React, { ReactNode, Component, ChangeEvent } from "react";
+import {
+  Tooltip,
+  IconButton,
+  Accordion,
+  AccordionSummary,
+  Typography,
+  AccordionDetails,
+} from "@material-ui/core";
+
+import {
+  ExpandMore,
+  AllOut,
+  Brush,
+  RadioButtonUncheckedSharp,
+} from "@material-ui/icons";
+
+import { usePaintbrushStore } from "./Store";
+
+type Tool = "paintbrush" | "eraser";
+
+interface Props {
+  expanded: boolean;
+  activeTool: Tool;
+  onChange: (event: ChangeEvent, isExpanded: boolean) => void;
+  activateTool: (tool: Tool) => void;
+}
+
+const PaintbrushUI = (props: Props) => {
+  const [paintbrush, setPaintbrush] = usePaintbrushStore();
+
+  function incrementBrush() {
+    setPaintbrush({ brushRadius: paintbrush.brushRadius + 10 });
+  }
+
+  return (
+    <Accordion expanded={props.expanded} onChange={props.onChange}>
+      <AccordionSummary expandIcon={<ExpandMore />} id="paintbrush-toolbox">
+        <Typography>Paintbrushes</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        <Tooltip title="Activate paintbrush">
+          <IconButton
+            id="activate-paintbrush"
+            onClick={() => props.activateTool("paintbrush")}
+            color={props.activeTool === "paintbrush" ? "secondary" : "default"}
+          >
+            <Brush />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title="Increase brush size">
+          <IconButton id="increase-paintbrush-radius" onClick={incrementBrush}>
+            <AllOut />
+          </IconButton>
+        </Tooltip>
+
+        <Tooltip title="Activate Eraser">
+          <IconButton
+            id="activate-eraser"
+            onClick={() => props.activateTool("eraser")}
+            color={props.activeTool === "eraser" ? "secondary" : "default"}
+          >
+            <RadioButtonUncheckedSharp />
+          </IconButton>
+        </Tooltip>
+      </AccordionDetails>
+    </Accordion>
+  );
+};
+
+export { PaintbrushUI };

--- a/src/toolboxes/paintbrush/index.ts
+++ b/src/toolboxes/paintbrush/index.ts
@@ -1,1 +1,2 @@
 export { PaintbrushCanvas } from "./Canvas";
+export { PaintbrushUI } from "./UI";

--- a/src/toolboxes/spline/UI.tsx
+++ b/src/toolboxes/spline/UI.tsx
@@ -1,0 +1,41 @@
+import React, { ChangeEvent } from "react";
+import {
+  Tooltip,
+  IconButton,
+  Accordion,
+  AccordionSummary,
+  Typography,
+  AccordionDetails,
+} from "@material-ui/core";
+
+import { ExpandMore, Brush } from "@material-ui/icons";
+
+import { Tool } from "@/tools";
+
+interface Props {
+  expanded: boolean;
+  activeTool: Tool;
+  onChange: (event: ChangeEvent, isExpanded: boolean) => void;
+  activateTool: (tool: Tool) => void;
+}
+
+const SplineUI = (props: Props) => (
+  <Accordion expanded={props.expanded} onChange={props.onChange}>
+    <AccordionSummary expandIcon={<ExpandMore />} id="spline-toolbox">
+      <Typography>Splines</Typography>
+    </AccordionSummary>
+    <AccordionDetails>
+      <Tooltip title="Activate spline">
+        <IconButton
+          id="activate-spline"
+          onClick={() => props.activateTool("spline")}
+          color={props.activeTool === "spline" ? "secondary" : "default"}
+        >
+          <Brush />
+        </IconButton>
+      </Tooltip>
+    </AccordionDetails>
+  </Accordion>
+);
+
+export { SplineUI };

--- a/src/toolboxes/spline/UI.tsx
+++ b/src/toolboxes/spline/UI.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from "react";
+import React, { ChangeEvent, ReactElement } from "react";
 import {
   Tooltip,
   IconButton,
@@ -19,7 +19,7 @@ interface Props {
   activateTool: (tool: Tool) => void;
 }
 
-const SplineUI = (props: Props) => (
+const SplineUI = (props: Props): ReactElement => (
   <Accordion expanded={props.expanded} onChange={props.onChange}>
     <AccordionSummary expandIcon={<ExpandMore />} id="spline-toolbox">
       <Typography>Splines</Typography>

--- a/src/toolboxes/spline/index.ts
+++ b/src/toolboxes/spline/index.ts
@@ -1,1 +1,2 @@
 export { SplineCanvas, events } from "./Canvas";
+export { SplineUI } from "./UI";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,0 +1,7 @@
+export const Tools = {
+  paintbrush: "paintbrush",
+  eraser: "eraser",
+  spline: "spline",
+} as const;
+
+export type Tool = typeof Tools[keyof typeof Tools];

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -73,19 +73,9 @@ interface State {
   imageHeight: number;
   activeAnnotationID: number;
 
-  viewportPositionAndSize: {
-    top: number;
-    left: number;
-    width: number;
-    height: number;
-  };
+  viewportPositionAndSize: Required<PositionAndSize>;
 
-  minimapPositionAndSize: {
-    top: number;
-    left: number;
-    width: number;
-    height: number;
-  };
+  minimapPositionAndSize: Required<PositionAndSize>;
 
   expanded: string | boolean;
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -26,7 +26,6 @@ import {
   KeyboardArrowRight,
   KeyboardArrowUp,
   ExpandMore,
-  Brush,
 } from "@material-ui/icons";
 
 import { Annotations } from "./annotation";
@@ -34,7 +33,7 @@ import { Annotations } from "./annotation";
 import { ThemeProvider, theme } from "./theme";
 
 import { BackgroundCanvas, BackgroundMinimap } from "./toolboxes/background";
-import { SplineCanvas } from "./toolboxes/spline";
+import { SplineCanvas, SplineUI } from "./toolboxes/spline";
 import { PaintbrushCanvas, PaintbrushUI } from "./toolboxes/paintbrush";
 import { Labels } from "./components/Labels";
 import { BaseSlider } from "./components/BaseSlider";
@@ -44,6 +43,7 @@ import { keydownListener } from "./keybindings";
 // Define all mutually exclusive tools
 // enum Tools {
 //   paintbrush = "paintbrush",
+
 //   spline = "spline",
 //   eraser = "eraser",
 // }
@@ -521,29 +521,12 @@ export class UserInterface extends Component<Record<string, never>, State> {
               activateTool={this.activateTool}
             />
 
-            <Accordion
+            <SplineUI
               expanded={this.state.expanded === "spline-toolbox"}
+              activeTool={this.state.activeTool}
               onChange={this.handleToolboxChange("spline-toolbox")}
-            >
-              <AccordionSummary expandIcon={<ExpandMore />} id="spline-toolbox">
-                <Typography>Splines</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Tooltip title="Activate spline">
-                  <IconButton
-                    id="activate-spline"
-                    onClick={this.selectSplineTool}
-                    color={
-                      this.state.activeTool === Tools.spline
-                        ? "secondary"
-                        : "default"
-                    }
-                  >
-                    <Brush />
-                  </IconButton>
-                </Tooltip>
-              </AccordionDetails>
-            </Accordion>
+              activateTool={this.activateTool}
+            />
 
             <Accordion
               expanded={this.state.expanded === "labels-toolbox"}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -298,10 +298,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
     this.incrementScaleAndPan("y", -CONFIG.PAN_AMOUNT);
   };
 
-  toggleEraser = (): void => {
-    this.setState({ activeTool: Tools.eraser });
-  };
-
   updateImageDimensions = (imageWidth: number, imageHeight: number): void => {
     this.setState({
       imageWidth,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -32,21 +32,15 @@ import { Annotations } from "./annotation";
 
 import { ThemeProvider, theme } from "./theme";
 
-import { BackgroundCanvas, BackgroundMinimap } from "./toolboxes/background";
+import {
+  BackgroundCanvas,
+  BackgroundMinimap,
+  BackgroundUI,
+} from "./toolboxes/background";
 import { SplineCanvas, SplineUI } from "./toolboxes/spline";
 import { PaintbrushCanvas, PaintbrushUI } from "./toolboxes/paintbrush";
 import { Labels } from "./components/Labels";
-import { BaseSlider } from "./components/BaseSlider";
-import { Sliders, SLIDER_CONFIG } from "./configSlider";
 import { keydownListener } from "./keybindings";
-
-// Define all mutually exclusive tools
-// enum Tools {
-//   paintbrush = "paintbrush",
-
-//   spline = "spline",
-//   eraser = "eraser",
-// }
 
 import { Tools, Tool } from "./tools";
 
@@ -78,8 +72,6 @@ interface State {
   imageWidth: number;
   imageHeight: number;
   activeAnnotationID: number;
-  contrast: number;
-  brightness: number;
 
   viewportPositionAndSize: {
     top: number;
@@ -121,8 +113,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
       viewportPositionAndSize: { top: 0, left: 0, width: 768, height: 768 },
       minimapPositionAndSize: { top: 0, left: 0, width: 200, height: 200 },
       expanded: false,
-      brightness: SLIDER_CONFIG[Sliders.brightness].initial,
-      contrast: SLIDER_CONFIG[Sliders.contrast].initial,
     };
 
     this.imageSource = "public/zebrafish-heart.jpg";
@@ -144,6 +134,12 @@ export class UserInterface extends Component<Record<string, never>, State> {
     }
   }
 
+  handleEvent = (event: Event): void => {
+    if (event.detail === "ui") {
+      this[event.type]?.call(this);
+    }
+  };
+
   setViewportPositionAndSize = (
     newViewportPositionAndSize: PositionAndSize
   ): void => {
@@ -160,12 +156,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
         },
       };
     });
-  };
-
-  handleEvent = (event: Event): void => {
-    if (event.detail === "ui") {
-      this[event.type]?.call(this);
-    }
   };
 
   setMinimapPositionAndSize = (
@@ -305,15 +295,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
     });
   };
 
-  selectSplineTool = (): void => {
-    // Change active tool to spline.
-    if (this.state.activeTool !== Tools.spline) {
-      this.setState({ activeTool: Tools.spline }, () => {
-        this.reuseEmptyAnnotation();
-      });
-    }
-  };
-
   activateTool = (tool: Tool): void => {
     this.setState({ activeTool: tool }, () => {
       this.reuseEmptyAnnotation();
@@ -369,13 +350,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
     this.setState({ expanded: isExpanded ? panel : false });
   };
 
-  handleSliderChange = <K extends keyof State>(key: K) => (
-    event: ChangeEvent,
-    value: State[K]
-  ): void => {
-    this.setState({ [key]: value } as Pick<State, K>);
-  };
-
   render = (): ReactNode => (
     <ThemeProvider theme={theme}>
       <CssBaseline />
@@ -399,8 +373,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
               updateImageDimensions={this.updateImageDimensions}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
-              contrast={this.state.contrast}
-              brightness={this.state.brightness}
             />
 
             <SplineCanvas
@@ -435,8 +407,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
                 canvasPositionAndSize={this.state.viewportPositionAndSize}
                 minimapPositionAndSize={this.state.minimapPositionAndSize}
                 setMinimapPositionAndSize={this.setMinimapPositionAndSize}
-                contrast={this.state.contrast}
-                brightness={this.state.brightness}
                 setCanvasPositionAndSize={this.setViewportPositionAndSize}
               />
             </div>
@@ -486,33 +456,10 @@ export class UserInterface extends Component<Record<string, never>, State> {
               </ButtonGroup>
             </Grid>
 
-            <Accordion
+            <BackgroundUI
               expanded={this.state.expanded === "background-toolbox"}
               onChange={this.handleToolboxChange("background-toolbox")}
-            >
-              <AccordionSummary
-                expandIcon={<ExpandMore />}
-                id="background-toolbox"
-              >
-                <Typography>Background</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Grid container spacing={0} justify="center" wrap="nowrap">
-                  <Grid item style={{ width: "85%", position: "relative" }}>
-                    <BaseSlider
-                      value={this.state.contrast}
-                      config={SLIDER_CONFIG[Sliders.contrast]}
-                      onChange={this.handleSliderChange}
-                    />
-                    <BaseSlider
-                      value={this.state.brightness}
-                      config={SLIDER_CONFIG[Sliders.brightness]}
-                      onChange={this.handleSliderChange}
-                    />
-                  </Grid>
-                </Grid>
-              </AccordionDetails>
-            </Accordion>
+            />
 
             <PaintbrushUI
               expanded={this.state.expanded === "paintbrush-toolbox"}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -318,22 +318,10 @@ export class UserInterface extends Component<Record<string, never>, State> {
     }
   };
 
-  selectPaintbrushTool = (): void => {
-    // Change active tool to paintbrush.
-    if (this.state.activeTool !== Tools.paintbrush) {
-      this.setState({ activeTool: Tools.paintbrush }, () => {
-        this.reuseEmptyAnnotation();
-      });
-    }
-  };
-
-  selectEraserTool = (): void => {
-    // Change active tool to paintbrush.
-    if (this.state.activeTool !== Tools.eraser) {
-      this.setState({ activeTool: Tools.eraser }, () => {
-        this.reuseEmptyAnnotation();
-      });
-    }
+  activateTool = (tool: Tool): void => {
+    this.setState({ activeTool: tool }, () => {
+      this.reuseEmptyAnnotation();
+    });
   };
 
   addAnnotation = (): void => {
@@ -532,13 +520,9 @@ export class UserInterface extends Component<Record<string, never>, State> {
 
             <PaintbrushUI
               expanded={this.state.expanded === "paintbrush-toolbox"}
-              activeTool={
-                this.state.activeTool === Tools.paintbrush
-                  ? "paintbrush"
-                  : "eraser"
-              }
+              activeTool={this.state.activeTool}
               onChange={this.handleToolboxChange("paintbrush-toolbox")}
-              activateTool={this.selectPaintbrushTool}
+              activateTool={this.activateTool}
             />
 
             <Accordion

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -50,6 +50,10 @@ import { keydownListener } from "./keybindings";
 
 import { Tools, Tool } from "./tools";
 
+const CONFIG = {
+  PAN_AMOUNT: 20,
+} as const;
+
 interface PositionAndSize {
   top?: number;
   left?: number;
@@ -276,22 +280,22 @@ export class UserInterface extends Component<Record<string, never>, State> {
 
   incrementPanX = (): void => {
     // negative is left, +ve is right...
-    this.incrementScaleAndPan("x", 20);
+    this.incrementScaleAndPan("x", CONFIG.PAN_AMOUNT);
   };
 
   decrementPanX = (): void => {
     // negative is left, +ve is right...
-    this.incrementScaleAndPan("x", -20);
+    this.incrementScaleAndPan("x", -CONFIG.PAN_AMOUNT);
   };
 
   incrementPanY = (): void => {
     // negative is up, +ve is down...
-    this.incrementScaleAndPan("y", 20);
+    this.incrementScaleAndPan("y", CONFIG.PAN_AMOUNT);
   };
 
   decrementPanY = (): void => {
     // negative is up, +ve is down...
-    this.incrementScaleAndPan("y", -20);
+    this.incrementScaleAndPan("y", -CONFIG.PAN_AMOUNT);
   };
 
   toggleEraser = (): void => {


### PR DESCRIPTION
Basically added a simple State store so  toolboxes can handle and share state without it being in the UI

the simple example is BrushRadius...it's set in the Paintbrush accordion and used in the canvas, but the main UI doesn't care about it, it way just a convenient place to store it

- Created Store helper module
- Moved PB UI to toolbox, added PB radius as internal state
- Moved Spline UI to toolbox
- Moved background UI to toolbox, moved brightness and contrast to internal toolbox state.