### PR TITLE
Chris baidoo/show existing paintbush layers

### DIFF
--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -60,11 +60,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
 
   componentDidUpdate(): void {
     // Redraw if we change pan or zoom
-    const activeAnnotation = this.props.annotationsObject.getActiveAnnotation();
-
-    if (activeAnnotation?.brushStrokes.length > 0) {
-      this.drawAllStrokes();
-    }
+    this.drawAllStrokes();
   }
 
   componentWillUnmount(): void {
@@ -175,18 +171,23 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
   };
 
   drawAllStrokes = (context = this.drawingCanvas.canvasContext): void => {
-    const { brushStrokes } = this.props.annotationsObject.getActiveAnnotation();
-
-    for (let i = 0; i < brushStrokes.length; i += 1) {
-      this.drawPoints(
-        brushStrokes[i].coordinates,
-        brushStrokes[i].brushColor,
-        brushStrokes[i].brushRadius,
-        brushStrokes[i].brushType,
-        false,
-        context
-      );
-    }
+    //Draw strokes on active layer whiles showing exiting paintbrush layers
+    this.props.annotationsObject
+      .getAllAnnotations()
+      .forEach((annotationsObject) => {
+        if (annotationsObject.toolbox === "paintbrush") {
+          for (let i = 0; i < annotationsObject.brushStrokes.length; i += 1) {
+            this.drawPoints(
+              annotationsObject.brushStrokes[i].coordinates,
+              annotationsObject.brushStrokes[i].brushColor,
+              annotationsObject.brushStrokes[i].brushRadius,
+              annotationsObject.brushStrokes[i].brushType,
+              false,
+              context
+            );
+          }
+        }
+      });
   };
 
   saveLine = (

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -171,7 +171,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
   };
 
   drawAllStrokes = (context = this.drawingCanvas.canvasContext): void => {
-    //Draw strokes on active layer whiles showing exiting paintbrush layers
+    // Draw strokes on active layer whiles showing exiting paintbrush layers
     this.props.annotationsObject
       .getAllAnnotations()
       .forEach((annotationsObject) => {


### PR DESCRIPTION
# Description
Continue to show existing paint brush layers when you create a new paintbrush layer just at low opacity, e.g. like splines.

closes (#73)


# Dependency changes
N/A

# Testing
N/A


# Documentation
N/A


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
