### PR TITLE
feat: Click to select annotations

### DIFF
--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -9,9 +9,9 @@ export const keybindings = {
   Enter: "spline.changeSplineModeToEdit",
   Escape: "spline.deselectPoint",
   "ctrl+KeyC": "spline.closeLoop",
+  "ctrl+KeyA": "spline-paintbrush.toggleMode",
   "ctrl+ArrowLeft": "ui.previousAnnotation",
   "ctrl+ArrowRight": "ui.nextAnnotation",
-  "ctrl+KeyA": "paintbrush.toggleMode",
 } as Readonly<{
   [key: string]: string;
 }>;

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -11,6 +11,7 @@ export const keybindings = {
   "ctrl+KeyC": "spline.closeLoop",
   "ctrl+ArrowLeft": "ui.previousAnnotation",
   "ctrl+ArrowRight": "ui.nextAnnotation",
+  "ctrl+KeyA": "paintbrush.toggleMode",
 } as Readonly<{
   [key: string]: string;
 }>;

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -34,7 +34,7 @@ enum Mode {
 
 interface State {
   hideBackCanvas: boolean;
-  mode: number;
+  mode: Mode;
 }
 
 // Here we define the methods that are exposed to be called by keyboard shortcuts
@@ -218,13 +218,13 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
 
   clickNearBrushStroke = (imageX: number, imageY: number): number => {
     // Check if point clicked is near an existing paintbrush annotation.
-    // If true, return annotation index, otherwise return -1.
+    // If true, return annotation index, otherwise return null.
     // If more than one annotation at clicked point, select first drawn.
     const annotations = this.props.annotationsObject.getAllAnnotations();
 
     for (let i = 0; i < annotations.length; i += 1) {
       if (annotations[i].toolbox === "paintbrush") {
-        let finalIndex = -1;
+        let finalIndex = null;
         for (let j = 0; j < annotations[i].brushStrokes.length; j += 1) {
           const { coordinates, brush } = annotations[i].brushStrokes[j];
           for (let k = 0; k < coordinates.length; k += 1) {
@@ -236,15 +236,15 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
               )
             ) {
               // If the region near the clicked point has been erased,
-              // finalIndex will be reset to - 1.
-              finalIndex = brush.type === "paint" ? i : -1;
+              // finalIndex will be reset to null.
+              finalIndex = brush.type === "paint" ? i : null;
             }
           }
         }
-        if (finalIndex !== -1) return i;
+        if (finalIndex !== null) return i;
       }
     }
-    return -1;
+    return null;
   };
 
   isClickNearPoint = (
@@ -326,7 +326,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
         this.props.canvasPositionAndSize
       );
       const selectedBrushStroke = this.clickNearBrushStroke(imageX, imageY);
-      if (selectedBrushStroke !== -1) {
+      if (selectedBrushStroke !== null) {
         this.props.annotationsObject.setActiveAnnotationID(selectedBrushStroke);
         this.drawAllStrokes();
       }

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -281,8 +281,8 @@ export class SplineCanvas extends Component<Props, State> {
     );
     const isClosed = this.isClosed(currentSplineVector);
 
-    // If the mouse click was near an existing point, nudge that point
     if (nudgePointIdx !== -1) {
+      // If the mouse click was near an existing point, nudge that point
       const nudgePoint = currentSplineVector[nudgePointIdx];
 
       this.updateXYPoint(
@@ -306,10 +306,26 @@ export class SplineCanvas extends Component<Props, State> {
       // Add coordinates to the current spline
       currentSplineVector.push({ x: imageX, y: imageY });
       this.selectedPointIndex = currentSplineVector.length - 1;
-    } else if (this.mode === Mode.edit) {
-      this.addNewPointNearSpline(imageX, imageY);
     }
+    // } else if (this.mode === Mode.edit) {
+    //   this.addNewPointNearSpline(imageX, imageY);
+    // }
 
+    this.drawAllSplines();
+  };
+
+  onDoubleClick = (x: number, y: number): void => {
+    // Add new point on double-click.
+    if (this.mode === Mode.draw) return;
+    const { x: imageX, y: imageY } = canvasToImage(
+      x,
+      y,
+      this.props.imageData.width,
+      this.props.imageData.height,
+      this.props.scaleAndPan,
+      this.props.canvasPositionAndSize
+    );
+    this.addNewPointNearSpline(imageX, imageY);
     this.drawAllSplines();
   };
 
@@ -427,6 +443,7 @@ export class SplineCanvas extends Component<Props, State> {
     <div style={{ pointerEvents: this.props.isActive ? "auto" : "none" }}>
       <BaseCanvas
         onClick={this.onClick}
+        onDoubleClick={this.onDoubleClick}
         onMouseDown={this.onMouseDown}
         onMouseMove={this.onMouseMove}
         onMouseUp={this.onMouseUp}

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -38,7 +38,7 @@ interface Event extends CustomEvent {
 
 type Cursor = "crosshair" | "pointer" | "none" | "not-allowed";
 interface State {
-  mode: number;
+  mode: Mode;
 }
 
 export class SplineCanvas extends Component<Props, State> {
@@ -330,7 +330,7 @@ export class SplineCanvas extends Component<Props, State> {
     } else if (this.state.mode === Mode.select) {
       // In select mode a single click allows to select a different spline
       const selectedSpline = this.clickNearSpline(imageX, imageY);
-      if (selectedSpline !== -1) {
+      if (selectedSpline !== null) {
         this.props.annotationsObject.setActiveAnnotationID(selectedSpline);
       }
     }
@@ -340,7 +340,7 @@ export class SplineCanvas extends Component<Props, State> {
 
   clickNearSpline = (imageX: number, imageY: number): number => {
     // Check if point clicked (in image space) is near an existing spline.
-    // If true, return annotation index, otherwise return -1.
+    // If true, return annotation index, otherwise return null.
     const annotations = this.props.annotationsObject.getAllAnnotations();
 
     for (let i = 0; i < annotations.length; i += 1) {
@@ -360,7 +360,7 @@ export class SplineCanvas extends Component<Props, State> {
         }
       }
     }
-    return -1;
+    return null;
   };
 
   isClickNearLineSegment = (
@@ -373,12 +373,13 @@ export class SplineCanvas extends Component<Props, State> {
     const dy = point.y - point1.y;
     const dxLine = point2.x - point1.x;
     const dyLine = point2.y - point1.y;
+    const distance = 700;
     // Use the cross-product to check whether the XYpoint lies on the line passing
     // through XYpoint 1 and XYpoint 2.
     const crossProduct = dx * dyLine - dy * dxLine;
     // If the XYpoint is exactly on the line the cross-product is zero. Here we set a threshold
     // based on ease of use, to accept points that are close enough to the spline.
-    if (Math.abs(crossProduct) > 700) return false;
+    if (Math.abs(crossProduct) > distance) return false;
 
     // Check if the point is on the segment (i.e., between point 1 and point 2).
     if (Math.abs(dxLine) >= Math.abs(dyLine)) {


### PR DESCRIPTION
# Description

Add the ability to select paintbrush or spline annotations with a single click on the annotation. When selected, an annotation becomes active and can then be modified or deleted.

For paintbrush annotations you can toggle between draw and select mode with ctrl+a (to try this out, draw multiple annotations, ctrl+a, click on existing annotations and delete, ctrl+a and draw some more..).

closes #84 


# Dependency changes

No

# Testing

No

# Documentation

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
