### PR TITLE
feat: move the buttons around a bit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gliff-ai/annotate",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gliff-ai/annotate",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@material-ui/core": "^4.11.3",

--- a/src/components/Labels.tsx
+++ b/src/components/Labels.tsx
@@ -74,53 +74,56 @@ export const Labels: FunctionComponent<Props> = ({
   }, [activeAnnotationID]);
 
   return (
-    <List style={{ width: "100%" }}>
-      <ListItem button onClick={handleClick}>
-        <ListItemIcon>
-          <LibraryAddIcon />
-          {isOpen ? <ExpandLess /> : <ExpandMore />}
-        </ListItemIcon>
-      </ListItem>
-
-      <Collapse
-        in={isOpen}
-        timeout="auto"
-        unmountOnExit
-        style={{
-          backgroundColor: theme.palette.divider,
-        }}
-      >
-        <List component="div" disablePadding>
-          {menuLabels.map((label) => (
-            <ListItem key={label} dense>
-              <ListItemText primary={label} />
-              <ListItemSecondaryAction>
-                <IconButton
-                  edge="end"
-                  aria-label="add"
-                  onClick={handleAddLabel(label)}
-                >
-                  <AddIcon />
-                </IconButton>
-              </ListItemSecondaryAction>
-            </ListItem>
-          ))}
-        </List>
-      </Collapse>
-      {assignedLabels.map((label) => (
-        <ListItem key={label} dense>
-          <ListItemText primary={label} />
-          <ListItemSecondaryAction>
-            <IconButton
-              edge="end"
-              aria-label="delete"
-              onClick={handleRemoveLabel(label)}
-            >
-              <BackspaceIcon />
-            </IconButton>
-          </ListItemSecondaryAction>
+    <div>
+      <List style={{ width: "100%" }}>
+        <ListItem button onClick={handleClick}>
+          <ListItemIcon>
+            Add Labels&nbsp;
+            <LibraryAddIcon />
+            {isOpen ? <ExpandLess /> : <ExpandMore />}
+          </ListItemIcon>
         </ListItem>
-      ))}
-    </List>
+
+        <Collapse
+          in={isOpen}
+          timeout="auto"
+          unmountOnExit
+          style={{
+            backgroundColor: theme.palette.divider,
+          }}
+        >
+          <List component="div" disablePadding>
+            {menuLabels.map((label) => (
+              <ListItem key={label} dense>
+                <ListItemText primary={label} />
+                <ListItemSecondaryAction>
+                  <IconButton
+                    edge="end"
+                    aria-label="add"
+                    onClick={handleAddLabel(label)}
+                  >
+                    <AddIcon />
+                  </IconButton>
+                </ListItemSecondaryAction>
+              </ListItem>
+            ))}
+          </List>
+        </Collapse>
+        {assignedLabels.map((label) => (
+          <ListItem key={label} dense>
+            <ListItemText primary={label} />
+            <ListItemSecondaryAction>
+              <IconButton
+                edge="end"
+                aria-label="delete"
+                onClick={handleRemoveLabel(label)}
+              >
+                <BackspaceIcon />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </ListItem>
+        ))}
+      </List>
+    </div>
   );
 };

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -366,11 +366,7 @@ export class UserInterface extends Component<Record<string, never>, State> {
       <Container disableGutters>
         <AppBar>
           <Toolbar>
-            <Tooltip title="Annotate new object">
-              <IconButton id="addAnnotation" onClick={this.addAnnotation}>
-                <Add />
-              </IconButton>
-            </Tooltip>
+            <Upload3DImage setUploadedImage={this.setUploadedImage} />
           </Toolbar>
         </AppBar>
         <Toolbar />
@@ -490,6 +486,40 @@ export class UserInterface extends Component<Record<string, never>, State> {
               </ButtonGroup>
             </Grid>
 
+            <Accordion
+              expanded={this.state.expanded === "labels-toolbox"}
+              onChange={this.handleToolboxChange("labels-toolbox")}
+            >
+              <AccordionSummary expandIcon={<ExpandMore />} id="labels-toolbox">
+                <Typography>Annotations</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Grid container justify="center">
+                  <ButtonGroup>
+                    <Tooltip title="Annotate new object">
+                      <Button id="addAnnotation" onClick={this.addAnnotation}>
+                        <Add />
+                      </Button>
+                    </Tooltip>
+                    <Tooltip title="Clear selected annotation">
+                      <Button
+                        id="clear-annotation"
+                        onClick={this.clearActiveAnnotation}
+                      >
+                        <Delete />
+                      </Button>
+                    </Tooltip>
+                  </ButtonGroup>
+
+                  <Labels
+                    annotationObject={this.annotationsObject}
+                    presetLabels={this.presetLabels}
+                    activeAnnotationID={this.state.activeAnnotationID}
+                  />
+                </Grid>
+              </AccordionDetails>
+            </Accordion>
+
             <BackgroundUI
               expanded={this.state.expanded === "background-toolbox"}
               onChange={this.handleToolboxChange("background-toolbox")}
@@ -514,36 +544,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
               onChange={this.handleToolboxChange("spline-toolbox")}
               activateTool={this.activateTool}
             />
-
-            <Accordion
-              expanded={this.state.expanded === "labels-toolbox"}
-              onChange={this.handleToolboxChange("labels-toolbox")}
-            >
-              <AccordionSummary expandIcon={<ExpandMore />} id="labels-toolbox">
-                <Typography>Labels</Typography>
-              </AccordionSummary>
-              <AccordionDetails>
-                <Labels
-                  annotationObject={this.annotationsObject}
-                  presetLabels={this.presetLabels}
-                  activeAnnotationID={this.state.activeAnnotationID}
-                />
-              </AccordionDetails>
-            </Accordion>
-
-            <Grid container justify="center">
-              <ButtonGroup orientation="vertical" style={{ margin: "5px" }}>
-                <Upload3DImage setUploadedImage={this.setUploadedImage} />
-                <Tooltip title="Clear selected annotation">
-                  <Button
-                    id="clear-annotation"
-                    onClick={this.clearActiveAnnotation}
-                  >
-                    <Delete />
-                  </Button>
-                </Tooltip>
-              </ButtonGroup>
-            </Grid>
           </Grid>
         </Grid>
       </Container>


### PR DESCRIPTION
# Description

I've moved the add object, delete object buttons into 'Layers', given they're basically the same sort of object. And moved Layers up to the top of the accordion.

Moved the load image button into the app bar.

# Dependency changes

None

# Testing

None

# Documentation

None

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
