### PR TITLE
feat: Use ImageBitmap and support more than 3 channels

### DIFF
--- a/src/baseCanvas/Canvas.tsx
+++ b/src/baseCanvas/Canvas.tsx
@@ -28,7 +28,7 @@ export interface Props {
   onContextMenu?: (x: number, y: number) => void;
   canvasPositionAndSize: PositionAndSize;
   setCanvasPositionAndSize?: (canvasPositionAndSize: PositionAndSize) => void;
-  imageData?: ImageData;
+  displayedImage?: ImageBitmap;
 }
 export class BaseCanvas extends Component<Props> {
   private name: string;
@@ -68,14 +68,6 @@ export class BaseCanvas extends Component<Props> {
 
   private applyView = (): void => {
     this.clearWindow();
-    // this.canvasContext.setTransform(
-    //   this.props.scaleAndPan.scale,
-    //   0,
-    //   0,
-    //   this.props.scaleAndPan.scale,
-    //   this.props.scaleAndPan.x,
-    //   this.props.scaleAndPan.y
-    // );
   };
 
   private handleCanvasResize = (entries: ResizeObserverEntry[]): void => {

--- a/src/baseCanvas/Minimap.tsx
+++ b/src/baseCanvas/Minimap.tsx
@@ -31,10 +31,10 @@ export class BaseMinimap extends React.Component<Props> {
   };
 
   private applyView = (): void => {
-    if (this.props.imageData) {
+    if (this.props.displayedImage) {
       this.boundingRect = getMinimapViewFinder(
-        this.props.imageData.width,
-        this.props.imageData.height,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
         this.props.scaleAndPan,
         this.props.canvasPositionAndSize,
         this.props.minimapPositionAndSize
@@ -62,13 +62,13 @@ export class BaseMinimap extends React.Component<Props> {
     const { x: targetX, y: targetY } = minimapToCanvas(
       minimapX,
       minimapY,
-      this.props.imageData.width,
-      this.props.imageData.height,
+      this.props.displayedImage.width,
+      this.props.displayedImage.height,
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize,
       this.props.minimapPositionAndSize
     );
-   
+
     // calculate the vector from the current canvas centre to the target position:
     const translateX = targetX - this.props.canvasPositionAndSize.width / 2;
     const translateY = targetY - this.props.canvasPositionAndSize.height / 2;

--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -11,7 +11,9 @@ interface Props extends BaseProps {
   setDisplayedImage: (displayedImage: ImageBitmap) => void;
   contrast: number;
   brightness: number;
-  channels: boolean[];
+  sliceChannelsImages: Array<ImageBitmap>;
+  channel: boolean[];
+  setChannels: any;
 }
 
 export class BackgroundCanvasClass extends Component<Props> {
@@ -36,40 +38,8 @@ export class BackgroundCanvasClass extends Component<Props> {
       this.updateBrightnessOrContrast();
     }
 
-    if (this.props.displayedImage !== undefined) {
-      // Update number of channels displayed
-
-      const colour = `#${this.props.channels
-        .map((channel: boolean) => (channel ? "FF" : "00"))
-        .join("")}FF`;
-
-      const { canvasContext } = this.baseCanvas;
-      canvasContext.globalCompositeOperation = "multiply";
-      canvasContext.fillStyle = colour;
-      const topLeft = imageToCanvas(
-        0,
-        0,
-        this.props.displayedImage.width,
-        this.props.displayedImage.height,
-        this.props.scaleAndPan,
-        this.props.canvasPositionAndSize
-      );
-      const imageScalingFactor = Math.min(
-        this.props.canvasPositionAndSize.width /
-          this.props.displayedImage.width,
-        this.props.canvasPositionAndSize.height /
-          this.props.displayedImage.height
-      );
-      canvasContext.fillRect(
-        topLeft.x,
-        topLeft.y,
-        this.props.displayedImage.width *
-          imageScalingFactor *
-          this.props.scaleAndPan.scale,
-        this.props.displayedImage.height *
-          imageScalingFactor *
-          this.props.scaleAndPan.scale
-      );
+    if (prevProps.channel !== this.props.channel) {
+      this.drawChannelImages();
     }
   }
 
@@ -90,11 +60,21 @@ export class BackgroundCanvasClass extends Component<Props> {
         );
       }
     } else {
-      drawImageOnCanvas(
-        this.baseCanvas.canvasContext,
-        this.image,
-        this.props.scaleAndPan
-      );
+      this.drawChannelImages();
+    }
+  };
+
+  private drawChannelImages = () => {
+    const { canvasContext } = this.baseCanvas;
+    canvasContext.globalCompositeOperation = "lighter";
+    for (let i = 0; i < this.props.sliceChannelsImages.length; i += 1) {
+      if (this.props.channel[i]) {
+        drawImageOnCanvas(
+          canvasContext,
+          this.props.sliceChannelsImages[i],
+          this.props.scaleAndPan
+        );
+      }
     }
   };
 
@@ -120,21 +100,9 @@ export class BackgroundCanvasClass extends Component<Props> {
       };
       this.image.src = this.props.imgSrc;
     } else {
-      // this.image = this.createCanvasFromImageData();
-      this.image = this.props.displayedImage;
       this.drawImage();
     }
   };
-
-  // private createCanvasFromImageData = (): HTMLCanvasElement => {
-  //   // Create a canvas element from an array.
-  //   const canvas = document.createElement("canvas");
-  //   const context = canvas.getContext("2d");
-  //   canvas.width = this.props.imageData.width;
-  //   canvas.height = this.props.imageData.height;
-  //   context.putImageData(this.props.imageData, 0, 0);
-  //   return canvas;
-  // };
 
   updateBrightnessOrContrast = (): void => {
     // Update image brightness and contrast
@@ -165,10 +133,12 @@ export const BackgroundCanvas = (
       setDisplayedImage={props.setDisplayedImage}
       contrast={background.contrast}
       brightness={background.brightness}
-      channels={background.channels}
+      channel={props.channel}
+      setChannels={props.setChannels}
       scaleAndPan={props.scaleAndPan}
       canvasPositionAndSize={props.canvasPositionAndSize}
       displayedImage={props.displayedImage}
+      sliceChannelsImages={props.sliceChannelsImages}
     />
   );
 };

--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -8,7 +8,7 @@ import { useBackgroundStore } from "./Store";
 
 interface Props extends BaseProps {
   imgSrc: string | null;
-  updateDisplayedImage: (displayedImage: ImageBitmap) => void;
+  setDisplayedImage: (displayedImage: ImageBitmap) => void;
   contrast: number;
   brightness: number;
   channels: boolean[];
@@ -106,7 +106,7 @@ export class BackgroundCanvasClass extends Component<Props> {
       this.image.crossOrigin = "anonymous";
       // Draw the image once loaded
       this.image.onload = async () => {
-        this.props.updateDisplayedImage(
+        this.props.setDisplayedImage(
           await createImageBitmap(
             this.baseCanvas.canvasContext.getImageData(
               0,
@@ -162,7 +162,7 @@ export const BackgroundCanvas = (
   return (
     <BackgroundCanvasClass
       imgSrc={props.imgSrc}
-      updateDisplayedImage={props.updateDisplayedImage}
+      setDisplayedImage={props.setDisplayedImage}
       contrast={background.contrast}
       brightness={background.brightness}
       channels={background.channels}

--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -12,7 +12,7 @@ interface Props extends BaseProps {
   contrast: number;
   brightness: number;
   sliceChannelsImages: Array<ImageBitmap>;
-  channel: boolean[];
+  channels: boolean[];
   setChannels: any;
 }
 
@@ -38,7 +38,7 @@ export class BackgroundCanvasClass extends Component<Props> {
       this.updateBrightnessOrContrast();
     }
 
-    if (prevProps.channel !== this.props.channel) {
+    if (prevProps.channels !== this.props.channels) {
       this.drawChannelImages();
     }
   }
@@ -65,10 +65,12 @@ export class BackgroundCanvasClass extends Component<Props> {
   };
 
   private drawChannelImages = () => {
+    // Draw all selected channel images on the canvas
     const { canvasContext } = this.baseCanvas;
-    canvasContext.globalCompositeOperation = "lighter";
+    canvasContext.globalCompositeOperation = "lighter"; // Where images overlap add colour values
+
     for (let i = 0; i < this.props.sliceChannelsImages.length; i += 1) {
-      if (this.props.channel[i]) {
+      if (this.props.channels[i]) {
         drawImageOnCanvas(
           canvasContext,
           this.props.sliceChannelsImages[i],
@@ -123,7 +125,7 @@ export class BackgroundCanvasClass extends Component<Props> {
 }
 
 export const BackgroundCanvas = (
-  props: Omit<Props, "contrast" | "brightness" | "channels">
+  props: Omit<Props, "contrast" | "brightness">
 ): ReactElement => {
   const [background] = useBackgroundStore();
 
@@ -133,7 +135,7 @@ export const BackgroundCanvas = (
       setDisplayedImage={props.setDisplayedImage}
       contrast={background.contrast}
       brightness={background.brightness}
-      channel={props.channel}
+      channels={props.channels}
       setChannels={props.setChannels}
       scaleAndPan={props.scaleAndPan}
       canvasPositionAndSize={props.canvasPositionAndSize}

--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -11,9 +11,7 @@ interface Props extends BaseProps {
   setDisplayedImage: (displayedImage: ImageBitmap) => void;
   contrast: number;
   brightness: number;
-  sliceChannelsImages: Array<ImageBitmap>;
   channels: boolean[];
-  setChannels: any;
 }
 
 export class BackgroundCanvasClass extends Component<Props> {
@@ -37,10 +35,6 @@ export class BackgroundCanvasClass extends Component<Props> {
     ) {
       this.updateBrightnessOrContrast();
     }
-
-    if (prevProps.channels !== this.props.channels) {
-      this.drawChannelImages();
-    }
   }
 
   componentDidMount = (): void => {
@@ -60,23 +54,11 @@ export class BackgroundCanvasClass extends Component<Props> {
         );
       }
     } else {
-      this.drawChannelImages();
-    }
-  };
-
-  private drawChannelImages = () => {
-    // Draw all selected channel images on the canvas
-    const { canvasContext } = this.baseCanvas;
-    canvasContext.globalCompositeOperation = "lighter"; // Where images overlap add colour values
-
-    for (let i = 0; i < this.props.sliceChannelsImages.length; i += 1) {
-      if (this.props.channels[i]) {
-        drawImageOnCanvas(
-          canvasContext,
-          this.props.sliceChannelsImages[i],
-          this.props.scaleAndPan
-        );
-      }
+      drawImageOnCanvas(
+        this.baseCanvas.canvasContext,
+        this.image,
+        this.props.scaleAndPan
+      );
     }
   };
 
@@ -102,6 +84,7 @@ export class BackgroundCanvasClass extends Component<Props> {
       };
       this.image.src = this.props.imgSrc;
     } else {
+      this.image = this.props.displayedImage;
       this.drawImage();
     }
   };
@@ -135,12 +118,10 @@ export const BackgroundCanvas = (
       setDisplayedImage={props.setDisplayedImage}
       contrast={background.contrast}
       brightness={background.brightness}
-      channels={props.channels}
-      setChannels={props.setChannels}
       scaleAndPan={props.scaleAndPan}
       canvasPositionAndSize={props.canvasPositionAndSize}
       displayedImage={props.displayedImage}
-      sliceChannelsImages={props.sliceChannelsImages}
+      channels={props.channels}
     />
   );
 };

--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -1,7 +1,6 @@
 import React, { Component, ReactNode, ReactElement } from "react";
 
 import { BaseCanvas, CanvasProps as BaseProps } from "@/baseCanvas";
-import { imageToCanvas } from "@/transforms";
 import drawImageOnCanvas from "./drawImage";
 
 import { useBackgroundStore } from "./Store";

--- a/src/toolboxes/background/Minimap.tsx
+++ b/src/toolboxes/background/Minimap.tsx
@@ -18,14 +18,14 @@ interface Props extends BaseProps {
 export class BackgroundMinimapClass extends Component<Props> {
   private baseMinimap: BaseMinimap;
 
-  private image: HTMLImageElement | HTMLCanvasElement;
+  private image: HTMLImageElement | ImageBitmap;
 
   componentDidMount = (): void => {
     this.loadImage();
   };
 
   componentDidUpdate(prevProps: Props): void {
-    if (prevProps.imageData !== this.props.imageData) {
+    if (prevProps.displayedImage !== this.props.displayedImage) {
       this.loadImage(); // calls this.drawImage() after image loading
     } else {
       this.drawImage();
@@ -50,7 +50,8 @@ export class BackgroundMinimapClass extends Component<Props> {
       };
       this.image.src = this.props.imgSrc;
     } else {
-      this.image = this.createCanvasFromImageData();
+      // this.image = this.createCanvasFromImageData();
+      this.image = this.props.displayedImage;
       this.drawImage();
     }
   };
@@ -59,15 +60,15 @@ export class BackgroundMinimapClass extends Component<Props> {
     this.baseMinimap.baseCanvas.canvasContext.filter = `contrast(${this.props.contrast}%) brightness(${this.props.brightness}%)`;
   };
 
-  private createCanvasFromImageData = (): HTMLCanvasElement => {
-    // Create a canvas element from an array.
-    const canvas = document.createElement("canvas");
-    const context = canvas.getContext("2d");
-    canvas.width = this.props.imageData.width;
-    canvas.height = this.props.imageData.height;
-    context.putImageData(this.props.imageData, 0, 0);
-    return canvas;
-  };
+  // private createCanvasFromImageData = (): HTMLCanvasElement => {
+  //   // Create a canvas element from an array.
+  //   const canvas = document.createElement("canvas");
+  //   const context = canvas.getContext("2d");
+  //   canvas.width = this.props.imageData.width;
+  //   canvas.height = this.props.imageData.height;
+  //   context.putImageData(this.props.imageData, 0, 0);
+  //   return canvas;
+  // };
 
   private drawImage = () => {
     // Any annotation that is already on the canvas is put on top of any new annotation
@@ -103,7 +104,7 @@ export class BackgroundMinimapClass extends Component<Props> {
         this.baseMinimap = baseMinimap;
       }}
       name="background-minimap"
-      imageData={this.props.imageData}
+      displayedImage={this.props.displayedImage}
       canvasPositionAndSize={this.props.canvasPositionAndSize}
       minimapPositionAndSize={this.props.minimapPositionAndSize}
       setMinimapPositionAndSize={this.props.setMinimapPositionAndSize}
@@ -125,7 +126,7 @@ export const BackgroundMinimap = (
       minimapPositionAndSize={props.minimapPositionAndSize}
       setScaleAndPan={props.setScaleAndPan}
       scaleAndPan={props.scaleAndPan}
-      imageData={props.imageData}
+      displayedImage={props.displayedImage}
     />
   );
 };

--- a/src/toolboxes/background/Minimap.tsx
+++ b/src/toolboxes/background/Minimap.tsx
@@ -60,16 +60,6 @@ export class BackgroundMinimapClass extends Component<Props> {
     this.baseMinimap.baseCanvas.canvasContext.filter = `contrast(${this.props.contrast}%) brightness(${this.props.brightness}%)`;
   };
 
-  // private createCanvasFromImageData = (): HTMLCanvasElement => {
-  //   // Create a canvas element from an array.
-  //   const canvas = document.createElement("canvas");
-  //   const context = canvas.getContext("2d");
-  //   canvas.width = this.props.imageData.width;
-  //   canvas.height = this.props.imageData.height;
-  //   context.putImageData(this.props.imageData, 0, 0);
-  //   return canvas;
-  // };
-
   private drawImage = () => {
     // Any annotation that is already on the canvas is put on top of any new annotation
     this.baseMinimap.baseCanvas.canvasContext.globalCompositeOperation =

--- a/src/toolboxes/background/Store.ts
+++ b/src/toolboxes/background/Store.ts
@@ -4,13 +4,13 @@ import { SLIDER_CONFIG, Sliders } from "./configSlider";
 interface BackgroundData {
   contrast: number;
   brightness: number;
-  channels: boolean[];
+  //channels: boolean[];
 }
 
 const defaultBackground: BackgroundData = {
   brightness: SLIDER_CONFIG[Sliders.brightness].initial,
   contrast: SLIDER_CONFIG[Sliders.contrast].initial,
-  channels: [true, true, true], // All channels selected
+  //channels: [true, true, true], // All channels selected
 };
 
 // we've created store with initial value. This can now be used anywhere and will share the value.

--- a/src/toolboxes/background/Store.ts
+++ b/src/toolboxes/background/Store.ts
@@ -4,13 +4,11 @@ import { SLIDER_CONFIG, Sliders } from "./configSlider";
 interface BackgroundData {
   contrast: number;
   brightness: number;
-  //channels: boolean[];
 }
 
 const defaultBackground: BackgroundData = {
   brightness: SLIDER_CONFIG[Sliders.brightness].initial,
   contrast: SLIDER_CONFIG[Sliders.contrast].initial,
-  //channels: [true, true, true], // All channels selected
 };
 
 // we've created store with initial value. This can now be used anywhere and will share the value.

--- a/src/toolboxes/background/UI.tsx
+++ b/src/toolboxes/background/UI.tsx
@@ -43,7 +43,7 @@ const BackgroundUI = (props: Props): ReactElement => {
     });
   }
 
-  let controls = [];
+  const controls = [];
   for (let i = 0; i < props.channels.length; i += 1) {
     controls[i] = (
       <Checkbox

--- a/src/toolboxes/background/UI.tsx
+++ b/src/toolboxes/background/UI.tsx
@@ -12,7 +12,7 @@ import {
   FormControl,
 } from "@material-ui/core";
 
-import { ExpandMore } from "@material-ui/icons";
+import { ExpandMore, PortraitSharp } from "@material-ui/icons";
 
 import { BaseSlider } from "@/components/BaseSlider";
 import { Sliders, SLIDER_CONFIG } from "./configSlider";
@@ -22,6 +22,8 @@ import { useBackgroundStore } from "./Store";
 interface Props {
   expanded: boolean;
   onChange: (event: ChangeEvent, isExpanded: boolean) => void;
+  channels: boolean[];
+  setChannels: (index: number) => void;
 }
 
 const BackgroundUI = (props: Props): ReactElement => {
@@ -31,7 +33,6 @@ const BackgroundUI = (props: Props): ReactElement => {
     setBackground({
       contrast: value,
       brightness: background.brightness,
-      channels: background.channels,
     });
   }
 
@@ -39,56 +40,30 @@ const BackgroundUI = (props: Props): ReactElement => {
     setBackground({
       brightness: value,
       contrast: background.contrast,
-      channels: background.channels,
     });
   }
 
-  function changeChannels(red = true, green = true, blue = true): void {
-    setBackground({
-      brightness: background.brightness,
-      contrast: background.contrast,
-      channels: [red, green, blue],
-    });
+  // function changeChannels(index: number): void {
+  //   const channels = background.channels;
+  //   channels[index] = !background.channels[index];
+  //   setBackground({
+  //     brightness: background.brightness,
+  //     contrast: background.contrast,
+  //     channels: channels,
+  //   });
+  // }
+
+  let controls = [];
+  for (let i = 0; i < props.channels.length; i += 1) {
+    controls[i] = (
+      <Checkbox
+        checked={props.channels[i]}
+        onChange={() => {
+          props.setChannels(i);
+        }}
+      />
+    );
   }
-
-  const control1 = (
-    <Checkbox
-      checked={background.channels[0]}
-      onChange={() => {
-        changeChannels(
-          !background.channels[0],
-          background.channels[1],
-          background.channels[2]
-        );
-      }}
-    />
-  );
-
-  const control2 = (
-    <Checkbox
-      checked={background.channels[1]}
-      onChange={() => {
-        changeChannels(
-          background.channels[0],
-          !background.channels[1],
-          background.channels[2]
-        );
-      }}
-    />
-  );
-
-  const control3 = (
-    <Checkbox
-      checked={background.channels[2]}
-      onChange={() => {
-        changeChannels(
-          background.channels[0],
-          background.channels[1],
-          !background.channels[2]
-        );
-      }}
-    />
-  );
 
   return (
     <Accordion expanded={props.expanded} onChange={props.onChange}>
@@ -112,27 +87,15 @@ const BackgroundUI = (props: Props): ReactElement => {
             <FormControl component="fieldset">
               <FormLabel component="legend">Channels</FormLabel>
               <FormGroup aria-label="position" row>
-                <FormControlLabel
-                  value="top"
-                  control={control1}
-                  label="R"
-                  labelPlacement="top"
-                  style={{ margin: "0", padding: "0" }}
-                />
-                <FormControlLabel
-                  value="top"
-                  control={control2}
-                  label="G"
-                  labelPlacement="top"
-                  style={{ margin: "0", padding: "0" }}
-                />
-                <FormControlLabel
-                  value="top"
-                  control={control3}
-                  label="B"
-                  labelPlacement="top"
-                  style={{ margin: "0", padding: "0" }}
-                />
+                {controls.map((control, i) => (
+                  <FormControlLabel
+                    value="top"
+                    control={control}
+                    label={`C${i + 1}`}
+                    labelPlacement="top"
+                    style={{ margin: "0", padding: "0" }}
+                  />
+                ))}
               </FormGroup>
             </FormControl>
           </Grid>

--- a/src/toolboxes/background/UI.tsx
+++ b/src/toolboxes/background/UI.tsx
@@ -12,7 +12,7 @@ import {
   FormControl,
 } from "@material-ui/core";
 
-import { ExpandMore, PortraitSharp } from "@material-ui/icons";
+import { ExpandMore } from "@material-ui/icons";
 
 import { BaseSlider } from "@/components/BaseSlider";
 import { Sliders, SLIDER_CONFIG } from "./configSlider";
@@ -43,17 +43,14 @@ const BackgroundUI = (props: Props): ReactElement => {
     });
   }
 
-  const controls = [];
-  for (let i = 0; i < props.channels.length; i += 1) {
-    controls[i] = (
-      <Checkbox
-        checked={props.channels[i]}
-        onChange={() => {
-          props.toggleChannelAtIndex(i);
-        }}
-      />
-    );
-  }
+  const controls = props.channels.map((channel, i) => (
+    <Checkbox
+      checked={channel}
+      onChange={() => {
+        props.toggleChannelAtIndex(i);
+      }}
+    />
+  ));
 
   return (
     <Accordion expanded={props.expanded} onChange={props.onChange}>
@@ -79,6 +76,7 @@ const BackgroundUI = (props: Props): ReactElement => {
               <FormGroup aria-label="position" row>
                 {controls.map((control, i) => (
                   <FormControlLabel
+                    key={`C${i + 1}`}
                     value="top"
                     control={control}
                     label={`C${i + 1}`}

--- a/src/toolboxes/background/UI.tsx
+++ b/src/toolboxes/background/UI.tsx
@@ -43,16 +43,6 @@ const BackgroundUI = (props: Props): ReactElement => {
     });
   }
 
-  // function changeChannels(index: number): void {
-  //   const channels = background.channels;
-  //   channels[index] = !background.channels[index];
-  //   setBackground({
-  //     brightness: background.brightness,
-  //     contrast: background.contrast,
-  //     channels: channels,
-  //   });
-  // }
-
   let controls = [];
   for (let i = 0; i < props.channels.length; i += 1) {
     controls[i] = (

--- a/src/toolboxes/background/UI.tsx
+++ b/src/toolboxes/background/UI.tsx
@@ -23,7 +23,7 @@ interface Props {
   expanded: boolean;
   onChange: (event: ChangeEvent, isExpanded: boolean) => void;
   channels: boolean[];
-  setChannels: (index: number) => void;
+  toggleChannelAtIndex: (index: number) => void;
 }
 
 const BackgroundUI = (props: Props): ReactElement => {
@@ -49,7 +49,7 @@ const BackgroundUI = (props: Props): ReactElement => {
       <Checkbox
         checked={props.channels[i]}
         onChange={() => {
-          props.setChannels(i);
+          props.toggleChannelAtIndex(i);
         }}
       />
     );

--- a/src/toolboxes/background/drawImage.ts
+++ b/src/toolboxes/background/drawImage.ts
@@ -1,6 +1,6 @@
 export default function drawImageOnCanvas(
   ctx: CanvasRenderingContext2D,
-  img: HTMLImageElement | HTMLCanvasElement,
+  img: HTMLImageElement | ImageBitmap,
   scaleAndPan: {
     x: number;
     y: number;
@@ -27,5 +27,4 @@ export default function drawImageOnCanvas(
 
   // fill image in dest. rectangle
   ctx.drawImage(img, offsetX, offsetY, newWidth, newHeight);
-
 }

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -202,7 +202,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     // Draw strokes on active layer whiles showing existing paintbrush layers
     this.props.annotationsObject
       .getAllAnnotations()
-      .forEach((annotationsObject, index) => {
+      .forEach((annotationsObject) => {
         if (annotationsObject.toolbox === "paintbrush") {
           annotationsObject.brushStrokes.forEach((brushStrokes) => {
             this.drawPoints(

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -94,8 +94,8 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     const { x, y } = canvasToImage(
       canvasX,
       canvasY,
-      this.props.imageData.width,
-      this.props.imageData.height,
+      this.props.displayedImage.width,
+      this.props.displayedImage.height,
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize
     );
@@ -138,8 +138,8 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
         const { x, y } = imageToCanvas(
           point.x,
           point.y,
-          this.props.imageData.width,
-          this.props.imageData.height,
+          this.props.displayedImage.width,
+          this.props.displayedImage.height,
           this.props.scaleAndPan,
           this.props.canvasPositionAndSize
         );
@@ -320,8 +320,8 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
       const { x: imageX, y: imageY } = canvasToImage(
         canvasX,
         canvasY,
-        this.props.imageData.width,
-        this.props.imageData.height,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
         this.props.scaleAndPan,
         this.props.canvasPositionAndSize
       );
@@ -421,7 +421,7 @@ export const PaintbrushCanvas = (
     <PaintbrushCanvasClass
       brushType={props.brushType}
       annotationsObject={props.annotationsObject}
-      imageData={props.imageData}
+      displayedImage={props.displayedImage}
       scaleAndPan={props.scaleAndPan}
       canvasPositionAndSize={props.canvasPositionAndSize}
       brushRadius={paintbrush.brushRadius}

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -116,8 +116,8 @@ export class SplineCanvas extends Component<Props, State> {
       firstPoint = imageToCanvas(
         firstPoint.x,
         firstPoint.y,
-        this.props.imageData.width,
-        this.props.imageData.height,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
         this.props.scaleAndPan,
         this.props.canvasPositionAndSize
       );
@@ -130,8 +130,8 @@ export class SplineCanvas extends Component<Props, State> {
         nextPoint = imageToCanvas(
           x,
           y,
-          this.props.imageData.width,
-          this.props.imageData.height,
+          this.props.displayedImage.width,
+          this.props.displayedImage.height,
           this.props.scaleAndPan,
           this.props.canvasPositionAndSize
         );
@@ -147,8 +147,8 @@ export class SplineCanvas extends Component<Props, State> {
         nextPoint = imageToCanvas(
           x,
           y,
-          this.props.imageData.width,
-          this.props.imageData.height,
+          this.props.displayedImage.width,
+          this.props.displayedImage.height,
           this.props.scaleAndPan,
           this.props.canvasPositionAndSize
         );
@@ -252,8 +252,8 @@ export class SplineCanvas extends Component<Props, State> {
     const { x: clickPointX, y: clickPointY } = imageToCanvas(
       clickPoint.x,
       clickPoint.y,
-      this.props.imageData.width,
-      this.props.imageData.height,
+      this.props.displayedImage.width,
+      this.props.displayedImage.height,
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize
     );
@@ -264,8 +264,8 @@ export class SplineCanvas extends Component<Props, State> {
       point = imageToCanvas(
         point.x,
         point.y,
-        this.props.imageData.width,
-        this.props.imageData.height,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
         this.props.scaleAndPan,
         this.props.canvasPositionAndSize
       );
@@ -289,8 +289,8 @@ export class SplineCanvas extends Component<Props, State> {
     const { x: imageX, y: imageY } = canvasToImage(
       x,
       y,
-      this.props.imageData.width,
-      this.props.imageData.height,
+      this.props.displayedImage.width,
+      this.props.displayedImage.height,
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize
     );
@@ -398,8 +398,8 @@ export class SplineCanvas extends Component<Props, State> {
     const { x: imageX, y: imageY } = canvasToImage(
       x,
       y,
-      this.props.imageData.width,
-      this.props.imageData.height,
+      this.props.displayedImage.width,
+      this.props.displayedImage.height,
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize
     );
@@ -435,8 +435,8 @@ export class SplineCanvas extends Component<Props, State> {
     const clickPoint = canvasToImage(
       x,
       y,
-      this.props.imageData.width,
-      this.props.imageData.height,
+      this.props.displayedImage.width,
+      this.props.displayedImage.height,
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize
     );
@@ -459,8 +459,8 @@ export class SplineCanvas extends Component<Props, State> {
     const clickPoint = canvasToImage(
       x,
       y,
-      this.props.imageData.width,
-      this.props.imageData.height,
+      this.props.displayedImage.width,
+      this.props.displayedImage.height,
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize
     );

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -64,7 +64,7 @@ interface State {
     scale: number;
   };
   activeTool?: Tool;
-  imageData?: ImageData;
+  displayedImage?: ImageBitmap;
   activeAnnotationID: number;
   imageLoaded: boolean;
   viewportPositionAndSize: Required<PositionAndSize>;
@@ -81,7 +81,7 @@ export class UserInterface extends Component<Record<string, never>, State> {
 
   private presetLabels: string[];
 
-  private slicesData: Array<ImageData>;
+  private slicesData: Array<Array<ImageBitmap>>;
 
   private imageFileInfo: ImageFileInfo | null;
 
@@ -202,18 +202,20 @@ export class UserInterface extends Component<Record<string, never>, State> {
 
     // calculate how much bigger the image is than the canvas, in canvas space:
     const imageScalingFactor = Math.min(
-      this.state.viewportPositionAndSize.width / this.state.imageData.width,
-      this.state.viewportPositionAndSize.height / this.state.imageData.height
+      this.state.viewportPositionAndSize.width /
+        this.state.displayedImage.width,
+      this.state.viewportPositionAndSize.height /
+        this.state.displayedImage.height
     );
 
     const xMargin =
-      this.state.imageData.width *
+      this.state.displayedImage.width *
         imageScalingFactor *
         this.state.scaleAndPan.scale -
       this.state.viewportPositionAndSize.width;
 
     const yMargin =
-      this.state.imageData.height *
+      this.state.displayedImage.height *
         imageScalingFactor *
         this.state.scaleAndPan.scale -
       this.state.viewportPositionAndSize.height;
@@ -278,18 +280,18 @@ export class UserInterface extends Component<Record<string, never>, State> {
     this.incrementScaleAndPan("y", -CONFIG.PAN_AMOUNT);
   };
 
-  updateImageData = (imageData: ImageData): void => {
-    this.setState({ imageData });
+  updateDisplayedImage = (displayedImage: ImageBitmap): void => {
+    this.setState({ displayedImage });
   };
 
   setUploadedImage = (
-    slicesData: Array<ImageData>,
+    slicesData: Array<Array<ImageBitmap>>,
     imageFileInfo: ImageFileInfo
   ): void => {
     this.imageFileInfo = imageFileInfo;
     this.slicesData = slicesData;
     this.setState({ imageLoaded: true, sliceIndex: 0 }, () => {
-      this.updateImageData(slicesData[0]); // go to first slice (if it's a 3D image)
+      this.updateDisplayedImage(slicesData[0][0]); // go to first slice (if it's a 3D image)
     });
   };
 
@@ -357,7 +359,10 @@ export class UserInterface extends Component<Record<string, never>, State> {
   };
 
   changeSlice = (e: ChangeEvent, value: number): void => {
-    this.setState({ sliceIndex: value, imageData: this.slicesData[value] });
+    this.setState({
+      sliceIndex: value,
+      displayedImage: this.slicesData[value][0],
+    });
   };
 
   render = (): ReactNode => (
@@ -376,8 +381,8 @@ export class UserInterface extends Component<Record<string, never>, State> {
             <BackgroundCanvas
               scaleAndPan={this.state.scaleAndPan}
               imgSrc={this.state.imageLoaded ? null : this.imageSource}
-              imageData={this.state.imageData}
-              updateImageData={this.updateImageData}
+              displayedImage={this.state.displayedImage}
+              updateDisplayedImage={this.updateDisplayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
             />
@@ -386,7 +391,7 @@ export class UserInterface extends Component<Record<string, never>, State> {
               scaleAndPan={this.state.scaleAndPan}
               isActive={this.state.activeTool === Tools.spline}
               annotationsObject={this.annotationsObject}
-              imageData={this.state.imageData}
+              displayedImage={this.state.displayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
               callRedraw={this.state.callRedraw}
@@ -396,13 +401,13 @@ export class UserInterface extends Component<Record<string, never>, State> {
               scaleAndPan={this.state.scaleAndPan}
               brushType={this.state.activeTool}
               annotationsObject={this.annotationsObject}
-              imageData={this.state.imageData}
+              displayedImage={this.state.displayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
               callRedraw={this.state.callRedraw}
             />
 
-            {this.state.imageLoaded && (
+            {this.state.imageLoaded && this.slicesData.length > 1 && (
               <div
                 style={{
                   position: "absolute",
@@ -433,7 +438,7 @@ export class UserInterface extends Component<Record<string, never>, State> {
                 scaleAndPan={this.state.scaleAndPan}
                 setScaleAndPan={this.setScaleAndPan}
                 imgSrc={this.state.imageLoaded ? null : this.imageSource}
-                imageData={this.state.imageData}
+                displayedImage={this.state.displayedImage}
                 canvasPositionAndSize={this.state.viewportPositionAndSize}
                 minimapPositionAndSize={this.state.minimapPositionAndSize}
                 setMinimapPositionAndSize={this.setMinimapPositionAndSize}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -293,15 +293,11 @@ export class UserInterface extends Component<Record<string, never>, State> {
         sliceIndex: 0,
         channels: Array(slicesData[0].length).fill(true) as boolean[],
       },
-      () => {
-        this.mixChannels().catch((error) => {
-          console.log(error);
-        });
-      }
+      this.mixChannels
     );
   };
 
-  mixChannels = async (): Promise<void> => {
+  mixChannels = (): void => {
     // combines the separate channels in this.slicesData[this.state.sliceIndex] into
     // a single ImageBitmap according to the user's channel picker settings, and stores
     // the result in this.state.displayedImage
@@ -320,12 +316,9 @@ export class UserInterface extends Component<Record<string, never>, State> {
       }
     );
 
-    try {
-      const displayedImage = await createImageBitmap(canvas);
-      this.setState({ displayedImage });
-    } catch (e) {
-      console.log(e);
-    }
+    createImageBitmap(canvas)
+      .then((displayedImage) => this.setState({ displayedImage }))
+      .catch((e) => console.log(e));
   };
 
   activateTool = (tool: Tool): void => {
@@ -396,11 +389,7 @@ export class UserInterface extends Component<Record<string, never>, State> {
       {
         sliceIndex: value,
       },
-      () => {
-        this.mixChannels().catch((error) => {
-          console.log(error);
-        });
-      }
+      this.mixChannels
     );
   };
 
@@ -409,18 +398,11 @@ export class UserInterface extends Component<Record<string, never>, State> {
   };
 
   toggleChannelAtIndex = (index: number): void => {
-    this.setState(
-      (prevState: State) => {
-        const { channels } = prevState;
-        channels[index] = !channels[index];
-        return { channels };
-      },
-      () => {
-        this.mixChannels().catch((error) => {
-          console.log(error);
-        });
-      }
-    );
+    this.setState((prevState: State) => {
+      const { channels } = prevState;
+      channels[index] = !channels[index];
+      return { channels };
+    }, this.mixChannels);
   };
 
   render = (): ReactNode => (

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -282,8 +282,8 @@ export class UserInterface extends Component<Record<string, never>, State> {
   updateDisplayedImage = async (): Promise<void> => {
     // Combine selected channels' data into single rbg image
 
-    const width = this.imageFileInfo.width;
-    const height = this.imageFileInfo.height;
+    const { width } = this.imageFileInfo;
+    const { height } = this.imageFileInfo;
     const rgbaImage = new Uint8ClampedArray(width * height * 4);
     const imageChannels = this.slicesData[this.state.sliceIndex];
 
@@ -309,7 +309,7 @@ export class UserInterface extends Component<Record<string, never>, State> {
       rgbaImage[4 * i + 3] = 255;
     }
 
-    //create a bitmap image from the channel slice data and store it inside displayedImage:
+    // create a bitmap image from the channel slice data and store it inside displayedImage:
     const displayedImage = await createImageBitmap(
       new ImageData(rgbaImage, width, height)
     );
@@ -325,7 +325,9 @@ export class UserInterface extends Component<Record<string, never>, State> {
 
     this.slicesData = slicesData;
     this.setState({ imageLoaded: true, sliceIndex: 0 }, () => {
-      this.updateDisplayedImage(); // go to first slice (if it's a 3D image)
+      this.updateDisplayedImage().catch((error) => {
+        console.log(error);
+      }); // go to first slice (if it's a 3D image)
     });
   };
 
@@ -398,7 +400,9 @@ export class UserInterface extends Component<Record<string, never>, State> {
         sliceIndex: value,
       },
       () => {
-        this.updateDisplayedImage();
+        this.updateDisplayedImage().catch((error) => {
+          console.log(error);
+        });
       }
     );
   };

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -4,7 +4,6 @@ import {
   Container,
   Toolbar,
   Tooltip,
-  IconButton,
   Button,
   ButtonGroup,
   Grid,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -420,7 +420,7 @@ export class UserInterface extends Component<Record<string, never>, State> {
                   : null
               }
               setChannels={this.setChannels}
-              channel={this.state.channels}
+              channels={this.state.channels}
             />
 
             <SplineCanvas
@@ -469,18 +469,18 @@ export class UserInterface extends Component<Record<string, never>, State> {
             )}
           </Grid>
           <Grid item style={{ width: 200, position: "relative" }}>
-            {/* <div style={{ height: 200 }}>
+            <div style={{ height: 200 }}>
               <BackgroundMinimap
                 scaleAndPan={this.state.scaleAndPan}
                 setScaleAndPan={this.setScaleAndPan}
                 imgSrc={this.state.imageLoaded ? null : this.imageSource}
-                displayedImage={this.state.displayedImage}
                 canvasPositionAndSize={this.state.viewportPositionAndSize}
                 minimapPositionAndSize={this.state.minimapPositionAndSize}
                 setMinimapPositionAndSize={this.setMinimapPositionAndSize}
                 setCanvasPositionAndSize={this.setViewportPositionAndSize}
+                displayedImage={this.state.displayedImage}
               />
-            </div> */}
+            </div>
 
             <Grid container justify="center">
               <ButtonGroup size="small" style={{ margin: "5px" }}>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -291,10 +291,12 @@ export class UserInterface extends Component<Record<string, never>, State> {
       {
         imageLoaded: true,
         sliceIndex: 0,
-        channels: Array(slicesData[0].length).fill(true),
+        channels: Array(slicesData[0].length).fill(true) as boolean[],
       },
       () => {
-        this.mixChannels();
+        this.mixChannels().catch((error) => {
+          console.log(error);
+        });
       }
     );
   };
@@ -390,21 +392,30 @@ export class UserInterface extends Component<Record<string, never>, State> {
         sliceIndex: value,
       },
       () => {
-        this.mixChannels();
+        this.mixChannels().catch((error) => {
+          console.log(error);
+        });
       }
     );
   };
 
-  setDisplayedImage = (displayedImage: ImageBitmap): void => {
-    this.setState({ displayedImage });
+  setDisplayedImage = (image: ImageBitmap): void => {
+    this.setState({ displayedImage: image });
   };
 
   toggleChannelAtIndex = (index: number): void => {
-    const channels = this.state.channels;
-    channels[index] = !channels[index];
-    this.setState({ channels }, () => {
-      this.mixChannels();
-    });
+    this.setState(
+      (prevState: State) => {
+        const { channels } = prevState;
+        channels[index] = !channels[index];
+        return { channels };
+      },
+      () => {
+        this.mixChannels().catch((error) => {
+          console.log(error);
+        });
+      }
+    );
   };
 
   render = (): ReactNode => (
@@ -427,7 +438,6 @@ export class UserInterface extends Component<Record<string, never>, State> {
               setDisplayedImage={this.setDisplayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
-              //toggleChannelAtIndex={this.toggleChannelAtIndex}
               channels={this.state.channels}
             />
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -320,7 +320,12 @@ export class UserInterface extends Component<Record<string, never>, State> {
       }
     );
 
-    this.setState({ displayedImage: await createImageBitmap(canvas) });
+    try {
+      const displayedImage = await createImageBitmap(canvas);
+      this.setState({ displayedImage });
+    } catch (e) {
+      console.log(e);
+    }
   };
 
   activateTool = (tool: Tool): void => {

--- a/src/upload3DImage.tsx
+++ b/src/upload3DImage.tsx
@@ -7,14 +7,14 @@ import ImageFileInfo from "./ImageFileInfo";
 interface Props {
   setUploadedImage: (
     imageFileInfo: ImageFileInfo,
-    slicesData?: Array<Array<Uint8ClampedArray>>
+    slicesData?: Array<Array<ImageBitmap>>
   ) => void;
 }
 
 export default class Upload3DImage extends Component<Props> {
   private imageFileInfo: ImageFileInfo | null;
 
-  private slicesData: Array<Array<Uint8ClampedArray>>;
+  private slicesData: Array<Array<ImageBitmap>>;
 
   constructor(props: Props) {
     super(props);
@@ -43,7 +43,7 @@ export default class Upload3DImage extends Component<Props> {
       console.log(error);
     });
 
-  private loadImageFile = (buffer: ArrayBuffer): void => {
+  private loadImageFile = async (buffer: ArrayBuffer): Promise<void> => {
     // Decode the images using the UTIF library.
     const ifds = UTIF.decode(buffer);
     ifds.forEach((ifd) => UTIF.decodeImage(buffer, ifd));
@@ -79,26 +79,64 @@ export default class Upload3DImage extends Component<Props> {
     const channels = this.getNumberOfChannels(descriptions);
 
     this.slicesData = [];
+    const slicesDataPromises: Promise<ImageBitmap>[][] = [];
 
     ifds.forEach((ifd, i) => {
       if (i % channels === 0) {
-        this.slicesData.push(new Array<Uint8ClampedArray>());
+        slicesDataPromises.push(new Array<Promise<ImageBitmap>>());
       }
 
       const sliceChannelRGBA8 = UTIF.toRGBA8(ifds[i]);
 
-      const sliceChannel = new Uint8ClampedArray(width * height);
-      for (let k = 0; k < width * height; k += 1) {
-        sliceChannel[k] = sliceChannelRGBA8[4 * k];
+      let sliceChannel = new Uint8ClampedArray(width * height * 4);
+      const channelIndex = channels - 1 - (i % channels); // channels are ordered backwards in ifds
+
+      if (channels === 1) {
+        sliceChannel = Uint8ClampedArray.from(sliceChannelRGBA8);
+      } else {
+        for (let j = 0; j < width * height; j += 1) {
+          if (channelIndex < 3) {
+            // channel 1-3: r,g,b
+            sliceChannel[4 * j + channelIndex] = sliceChannelRGBA8[4 * j];
+          } else if (channelIndex === 4) {
+            // channel 5: r+g or yellow
+            sliceChannel[4 * j + 0] = sliceChannelRGBA8[4 * j];
+            sliceChannel[4 * j + 1] = sliceChannelRGBA8[4 * j];
+          } else if (channelIndex === 5) {
+            // channel 5: r+b or magenta
+            sliceChannel[4 * j + 0] = sliceChannelRGBA8[4 * j];
+            sliceChannel[4 * j + 2] = sliceChannelRGBA8[4 * j];
+          } else if (channelIndex === 6) {
+            // channel 6: g+b or cyan
+            sliceChannel[4 * j + 1] = sliceChannelRGBA8[4 * j];
+            sliceChannel[4 * j + 2] = sliceChannelRGBA8[4 * j];
+          }
+          // set alpha to 255
+          sliceChannel[4 * j + 3] = 255;
+        }
       }
 
-      this.slicesData[Math.floor(i / channels)][
-        channels - 1 - (i % channels) // channels are ordered backwards in ifds
-      ] = sliceChannel;
+      slicesDataPromises[Math.floor(i / channels)][
+        channelIndex
+      ] = createImageBitmap(
+        //new ImageData(Uint8ClampedArray.from(sliceChannelRGBA8), width, height)
+        new ImageData(sliceChannel, width, height)
+      );
     });
 
     this.imageFileInfo.width = width;
     this.imageFileInfo.height = height;
+
+    // the linter complains if we await the createImageBitmaps inside a for loop, so instead we have to let the foo loop
+    // build a Promise<ImageBitmap>[][], and then use Promise.all twice to turn that into ImageBitmap[][]
+    // see https://eslint.org/docs/rules/no-await-in-loop
+    // also https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all
+    const halfUnwrapped: Promise<
+      ImageBitmap[]
+    >[] = slicesDataPromises.map(async (sliceChannels) =>
+      Promise.all(sliceChannels)
+    );
+    this.slicesData = await Promise.all(halfUnwrapped); // ImageBitmap[][]
 
     this.props.setUploadedImage(this.imageFileInfo, this.slicesData);
   };

--- a/src/upload3DImage.tsx
+++ b/src/upload3DImage.tsx
@@ -25,9 +25,7 @@ export default class Upload3DImage extends Component<Props> {
     this.readFile(imageFile)
       .then((buffer: ArrayBuffer) => {
         this.imageFileInfo = new ImageFileInfo(imageFile.name);
-        this.loadImageFile(buffer).catch((error) => {
-          console.log(error);
-        });
+        this.loadImageFile(buffer);
       })
       .catch((error) => {
         console.log(error);
@@ -45,7 +43,7 @@ export default class Upload3DImage extends Component<Props> {
       console.log(error);
     });
 
-  private loadImageFile = async (buffer: ArrayBuffer): Promise<void> => {
+  private loadImageFile = (buffer: ArrayBuffer): void => {
     // Decode the images using the UTIF library.
     const ifds = UTIF.decode(buffer);
     for (const ifd of ifds) {

--- a/src/upload3DImage.tsx
+++ b/src/upload3DImage.tsx
@@ -25,7 +25,9 @@ export default class Upload3DImage extends Component<Props> {
     this.readFile(imageFile)
       .then((buffer: ArrayBuffer) => {
         this.imageFileInfo = new ImageFileInfo(imageFile.name);
-        this.loadImageFile(buffer);
+        this.loadImageFile(buffer).catch((error) => {
+          console.log(error);
+        });
       })
       .catch((error) => {
         console.log(error);
@@ -97,7 +99,7 @@ export default class Upload3DImage extends Component<Props> {
       context.putImageData(imageData, 0, 0);
 
       let colour;
-      let channel = channels - 1 - (i % channels); // channels are in reverse order in ifds
+      const channel = channels - 1 - (i % channels); // channels are in reverse order in ifds
       if (channels > 1) {
         if (channel === 0) colour = "#FF0000FF";
         else if (channel === 1 && channels !== 2) colour = "#00FF00FF";

--- a/src/upload3DImage.tsx
+++ b/src/upload3DImage.tsx
@@ -46,7 +46,7 @@ export default class Upload3DImage extends Component<Props> {
   private loadImageFile = (buffer: ArrayBuffer): void => {
     // Decode the images using the UTIF library.
     const ifds = UTIF.decode(buffer);
-    ifds.map((ifd) => UTIF.decodeImage(buffer, ifd));
+    ifds.forEach((ifd) => UTIF.decodeImage(buffer, ifd));
 
     const { width, height } = ifds[0];
 
@@ -78,10 +78,9 @@ export default class Upload3DImage extends Component<Props> {
     const descriptions = ifds[0].t270 as string[];
     const channels = this.getNumberOfChannels(descriptions);
 
-    const slices = ifds.length / channels;
     this.slicesData = [];
 
-    ifds.map((ifd, i) => {
+    ifds.forEach((ifd, i) => {
       if (i % channels === 0) {
         this.slicesData.push(new Array<Uint8ClampedArray>());
       }

--- a/src/upload3DImage.tsx
+++ b/src/upload3DImage.tsx
@@ -161,11 +161,7 @@ export default class Upload3DImage extends Component<Props> {
         );
       }
     }
-    // TODO: check if we need this..
-    if (channels === 0) {
-      channels = 1;
-    }
-    return channels;
+    return channels || 1;
   };
 
   render = (): ReactNode => (

--- a/src/upload3DImage.tsx
+++ b/src/upload3DImage.tsx
@@ -97,7 +97,7 @@ export default class Upload3DImage extends Component<Props> {
       context.putImageData(imageData, 0, 0);
 
       let colour;
-      let channel = channels - 1 - (i % channels); // channels are ordered backwards in ifds
+      let channel = channels - 1 - (i % channels); // channels are in reverse order in ifds
       if (channels > 1) {
         if (channel === 0) colour = "#FF0000FF";
         else if (channel === 1 && channels !== 2) colour = "#00FF00FF";
@@ -116,9 +116,9 @@ export default class Upload3DImage extends Component<Props> {
         slicesDataPromises.push(new Array<Promise<ImageBitmap>>());
       }
 
-      slicesDataPromises[Math.floor(i / channels)][
-        i % channels
-      ] = createImageBitmap(canvas);
+      slicesDataPromises[Math.floor(i / channels)][channel] = createImageBitmap(
+        canvas
+      );
     });
 
     // the linter complains if we await the createImageBitmaps inside a for loop, so instead we have to let the for loop


### PR DESCRIPTION
# Description

- Replaced `ImageData` with `ImageBitmap` throughout the code. `ImageBitmap` is like `ImageData` but renders on canvases like 40x faster, however there's no easy way to get an array of pixel data out of it, unlike with `ImageData`. This theoretically makes the app a little faster, and allows us to simplify `BackgroundCanvas` a bit because we can pass `ImageBitmap` directly into `ctx.drawImage`, unlike `ImageData` which had to go via a `HTMLCanvasElement`.
- Added support for more than 3 channels.

closes #93

# Dependency changes

No

# Testing

No

# Documentation

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
