### PR TITLE
fix: Single-slice drawing for 3D images

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -76,9 +76,8 @@ export class Annotations {
   setSpaceTimeInfo = (z?: number, t?: number): void => {
     // Set space and time data for active annotation.
     if (z === undefined && t === undefined) return;
-    const { z: prevZ, t: prevT } = this.data[
-      this.activeAnnotationID
-    ].spaceTimeInfo;
+    const { z: prevZ, t: prevT } =
+      this.data[this.activeAnnotationID].spaceTimeInfo;
     this.data[this.activeAnnotationID].spaceTimeInfo = {
       z: z || prevZ,
       t: t || prevT,

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1,4 +1,10 @@
-import { Annotation, ZTPoint, XYPoint, BrushStrokes } from "./interfaces";
+import {
+  Annotation,
+  ZTPoint,
+  XYPoint,
+  BrushStroke,
+  Spline,
+} from "./interfaces";
 
 export class Annotations {
   private data: Array<Annotation>;
@@ -12,18 +18,19 @@ export class Annotations {
 
   addAnnotation = (
     toolbox: string,
-    spaceTimeInfo: ZTPoint = { z: 0, t: 0 },
     labels: string[] = [],
-    coordinates: XYPoint[] = [],
-    brushStrokes: BrushStrokes[] = [],
+    spline: Spline = {
+      coordinates: [],
+      spaceTimeInfo: { z: 0, t: 0 },
+    },
+    brushStrokes: BrushStroke[] = [],
     parameters: Annotation["parameters"] = {}
   ): void => {
     this.activeAnnotationID =
       this.data.push({
         labels,
         toolbox,
-        spaceTimeInfo,
-        coordinates,
+        spline,
         brushStrokes,
         parameters,
       }) - 1;
@@ -47,17 +54,20 @@ export class Annotations {
 
   getActiveAnnotation = (): Annotation => this.data[this.activeAnnotationID];
 
+  getSplineForActiveAnnotation = (): Spline =>
+    this.data[this.activeAnnotationID].spline;
+
   length = (): number => this.data.length;
 
   setActiveAnnotationID = (id: number): void => {
     this.activeAnnotationID = id;
   };
 
-  setAnnotationCoordinates = (newCoordinates: XYPoint[]): void => {
-    this.data[this.activeAnnotationID].coordinates = newCoordinates;
+  setSplineCoordinates = (newCoordinates: XYPoint[]): void => {
+    this.data[this.activeAnnotationID].spline.coordinates = newCoordinates;
   };
 
-  setAnnotationBrushStrokes = (newBrushStrokes: BrushStrokes[]): void => {
+  setAnnotationBrushStrokes = (newBrushStrokes: BrushStroke[]): void => {
     this.data[this.activeAnnotationID].brushStrokes = newBrushStrokes;
   };
 
@@ -68,17 +78,17 @@ export class Annotations {
   isActiveAnnotationEmpty = (): boolean =>
     // Check whether the active annotation object contains any
     // paintbrush or spline annotations.
-    this.data[this.activeAnnotationID].coordinates.length === 0 &&
+    this.data[this.activeAnnotationID].spline.coordinates.length === 0 &&
     this.data[this.activeAnnotationID].brushStrokes.length === 0;
 
   getAllAnnotations = (): Annotation[] => this.data;
 
-  setSpaceTimeInfo = (z?: number, t?: number): void => {
-    // Set space and time data for active annotation.
+  setSplineSpaceTimeInfo = (z?: number, t?: number): void => {
+    // Set space and time data for spline of active annotation.
     if (z === undefined && t === undefined) return;
     const { z: prevZ, t: prevT } =
-      this.data[this.activeAnnotationID].spaceTimeInfo;
-    this.data[this.activeAnnotationID].spaceTimeInfo = {
+      this.data[this.activeAnnotationID].spline.spaceTimeInfo;
+    this.data[this.activeAnnotationID].spline.spaceTimeInfo = {
       z: z || prevZ,
       t: t || prevT,
     };

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1,6 +1,5 @@
 import {
   Annotation,
-  ZTPoint,
   XYPoint,
   BrushStroke,
   Spline,

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -12,8 +12,8 @@ export class Annotations {
 
   addAnnotation = (
     toolbox: string,
-    labels: string[] = [],
     spaceTimeInfo: ZTPoint = { z: 0, t: 0 },
+    labels: string[] = [],
     coordinates: XYPoint[] = [],
     brushStrokes: BrushStrokes[] = [],
     parameters: Annotation["parameters"] = {}
@@ -72,4 +72,15 @@ export class Annotations {
     this.data[this.activeAnnotationID].brushStrokes.length === 0;
 
   getAllAnnotations = (): Annotation[] => this.data;
+
+  setSpaceTimeInfo = (z?: number, t?: number): void => {
+    // Set space and time data for active annotation.
+    const { z: prevZ, t: prevT } = this.data[
+      this.activeAnnotationID
+    ].spaceTimeInfo;
+    this.data[this.activeAnnotationID].spaceTimeInfo = {
+      z: z || prevZ,
+      t: t || prevT,
+    };
+  };
 }

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -75,6 +75,7 @@ export class Annotations {
 
   setSpaceTimeInfo = (z?: number, t?: number): void => {
     // Set space and time data for active annotation.
+    if (z === undefined && t === undefined) return;
     const { z: prevZ, t: prevT } = this.data[
       this.activeAnnotationID
     ].spaceTimeInfo;

--- a/src/annotation/interfaces.ts
+++ b/src/annotation/interfaces.ts
@@ -1,4 +1,4 @@
-export interface BrushStrokes {
+export interface BrushStroke {
   // Todo move this into Paintbrush Toolbox
   coordinates: XYPoint[];
   spaceTimeInfo: ZTPoint;
@@ -8,13 +8,15 @@ export interface BrushStrokes {
     color: string; // rgb(a) string
   };
 }
-
+export interface Spline {
+  coordinates: XYPoint[];
+  spaceTimeInfo: ZTPoint;
+}
 export interface Annotation {
   labels: string[];
   toolbox: string;
-  spaceTimeInfo: ZTPoint;
-  coordinates: XYPoint[];
-  brushStrokes: BrushStrokes[];
+  spline: Spline;
+  brushStrokes: BrushStroke[];
   parameters: Record<string, unknown>;
 }
 

--- a/src/annotation/interfaces.ts
+++ b/src/annotation/interfaces.ts
@@ -1,6 +1,7 @@
 export interface BrushStrokes {
   // Todo move this into Paintbrush Toolbox
   coordinates: XYPoint[];
+  spaceTimeInfo: ZTPoint;
   brush: {
     radius: number;
     type: "paint" | "erase";

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -405,7 +405,6 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
         this.props.canvasPositionAndSize
       );
       const selectedBrushStroke = this.clickNearBrushStroke(imageX, imageY);
-      console.log(selectedBrushStroke);
       if (selectedBrushStroke !== null) {
         this.props.annotationsObject.setActiveAnnotationID(selectedBrushStroke);
         this.drawAllStrokes();

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -189,19 +189,17 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     context: CanvasRenderingContext2D,
     isActive = true
   ): void => {
-    const points = imagePoints.map(
-      (point): XYPoint => {
-        const { x, y } = imageToCanvas(
-          point.x,
-          point.y,
-          this.props.displayedImage.width,
-          this.props.displayedImage.height,
-          this.props.scaleAndPan,
-          this.props.canvasPositionAndSize
-        );
-        return { x, y };
-      }
-    );
+    const points = imagePoints.map((point): XYPoint => {
+      const { x, y } = imageToCanvas(
+        point.x,
+        point.y,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
+        this.props.scaleAndPan,
+        this.props.canvasPositionAndSize
+      );
+      return { x, y };
+    });
 
     function midPointBetween(p1: XYPoint, p2: XYPoint) {
       return {
@@ -267,7 +265,8 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     // Draw strokes on active layer whiles showing existing paintbrush layers
 
     // Get active annotation ID
-    const activeAnnotationID = this.props.annotationsObject.getActiveAnnotationID();
+    const activeAnnotationID =
+      this.props.annotationsObject.getActiveAnnotationID();
 
     // Clear paintbrush canvas
     context.clearRect(0, 0, context.canvas.width, context.canvas.height);

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -300,7 +300,10 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     const annotations = this.props.annotationsObject.getAllAnnotations();
 
     for (let i = 0; i < annotations.length; i += 1) {
-      if (annotations[i].toolbox === "paintbrush") {
+      if (
+        annotations[i].spaceTimeInfo.z === this.props.sliceIndex &&
+        annotations[i].toolbox === "paintbrush"
+      ) {
         let finalIndex = null;
         for (let j = 0; j < annotations[i].brushStrokes.length; j += 1) {
           const { coordinates, brush } = annotations[i].brushStrokes[j];
@@ -376,9 +379,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
 
   /** * Mouse events *** */
   onMouseDown = (canvasX: number, canvasY: number): void => {
-    if (!this.sliceIndexMatch()) return;
-
-    if (this.state.mode === Mode.draw) {
+    if (this.state.mode === Mode.draw && this.sliceIndexMatch()) {
       // Start drawing
       if (this.props.brushType === "eraser") {
         // Copy the current BACK strokes to the front canvas
@@ -404,6 +405,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
         this.props.canvasPositionAndSize
       );
       const selectedBrushStroke = this.clickNearBrushStroke(imageX, imageY);
+      console.log(selectedBrushStroke);
       if (selectedBrushStroke !== null) {
         this.props.annotationsObject.setActiveAnnotationID(selectedBrushStroke);
         this.drawAllStrokes();

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -189,7 +189,8 @@ export class SplineCanvas extends Component<Props, State> {
 
     // Clear all the splines:
     const { canvasContext: context } = this.baseCanvas;
-    const activeAnnotationID = this.props.annotationsObject.getActiveAnnotationID();
+    const activeAnnotationID =
+      this.props.annotationsObject.getActiveAnnotationID();
     context.clearRect(0, 0, context.canvas.width, context.canvas.height);
 
     // Draw all the splines:
@@ -315,9 +316,8 @@ export class SplineCanvas extends Component<Props, State> {
     );
 
     if (this.sliceIndexMatch()) {
-      const {
-        coordinates,
-      } = this.props.annotationsObject.getActiveAnnotation();
+      const { coordinates } =
+        this.props.annotationsObject.getActiveAnnotation();
       // check if we clicked within the nudge radius of an existing point:
       const nudgePointIdx = this.clickNearPoint(
         { x: imageX, y: imageY },
@@ -569,9 +569,8 @@ export class SplineCanvas extends Component<Props, State> {
 
     if (this.state.mode === Mode.magic && this.numberOfMoves % 5 === 0) {
       // add a new point and snap it to the highest gradient point within 25 pixels:
-      const {
-        coordinates,
-      } = this.props.annotationsObject.getActiveAnnotation();
+      const { coordinates } =
+        this.props.annotationsObject.getActiveAnnotation();
       coordinates.push({ x: clickPoint.x, y: clickPoint.y });
       this.snapToGradient(
         coordinates.length - 1,
@@ -579,8 +578,8 @@ export class SplineCanvas extends Component<Props, State> {
       );
     } else {
       // If dragging first point, update also last
-      const activeSpline = this.props.annotationsObject.getActiveAnnotation()
-        .coordinates;
+      const activeSpline =
+        this.props.annotationsObject.getActiveAnnotation().coordinates;
       if (this.selectedPointIndex === 0 && this.isClosed(activeSpline)) {
         this.updateXYPoint(clickPoint.x, clickPoint.y, activeSpline.length - 1);
       }

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -228,11 +228,7 @@ export class SplineCanvas extends Component<Props, State> {
   };
 
   deleteSelectedPoint = (): void => {
-    if (this.selectedPointIndex === -1) return;
-    const {
-      spaceTimeInfo,
-    } = this.props.annotationsObject.getActiveAnnotation();
-    if (spaceTimeInfo.z !== this.props.sliceIndex) return;
+    if (this.selectedPointIndex === -1 || !this.sliceIndexMatch()) return;
 
     const { coordinates } = this.props.annotationsObject.getActiveAnnotation();
     const isClosed = this.isClosed(coordinates);
@@ -309,12 +305,9 @@ export class SplineCanvas extends Component<Props, State> {
 
   // X and Y are in CanvasSpace
   onClick = (x: number, y: number): void => {
-    const {
-      coordinates,
-      spaceTimeInfo,
-    } = this.props.annotationsObject.getActiveAnnotation();
-    if (spaceTimeInfo.z !== this.props.sliceIndex) return;
+    if (!this.sliceIndexMatch()) return;
 
+    const { coordinates } = this.props.annotationsObject.getActiveAnnotation();
     const { x: imageX, y: imageY } = canvasToImage(
       x,
       y,
@@ -423,11 +416,7 @@ export class SplineCanvas extends Component<Props, State> {
 
   onDoubleClick = (x: number, y: number): void => {
     // Add new point on double-click.
-    if (this.state.mode === Mode.draw) return;
-    const {
-      spaceTimeInfo,
-    } = this.props.annotationsObject.getActiveAnnotation();
-    if (spaceTimeInfo.z !== this.props.sliceIndex) return;
+    if (this.state.mode === Mode.draw || !this.sliceIndexMatch()) return;
 
     const { x: imageX, y: imageY } = canvasToImage(
       x,
@@ -448,12 +437,9 @@ export class SplineCanvas extends Component<Props, State> {
 
   closeLoop = (): void => {
     // Append the first spline point to the end, making a closed polygon
+    if (!this.sliceIndexMatch()) return;
 
-    const {
-      coordinates,
-      spaceTimeInfo,
-    } = this.props.annotationsObject.getActiveAnnotation();
-    if (spaceTimeInfo.z !== this.props.sliceIndex) return;
+    const { coordinates } = this.props.annotationsObject.getActiveAnnotation();
     if (coordinates.length < 3) {
       return; // need at least three points to make a closed polygon
     }
@@ -528,11 +514,9 @@ export class SplineCanvas extends Component<Props, State> {
   };
 
   onMouseDown = (x: number, y: number): void => {
-    const {
-      coordinates,
-      spaceTimeInfo,
-    } = this.props.annotationsObject.getActiveAnnotation();
-    if (spaceTimeInfo.z !== this.props.sliceIndex) return;
+    if (!this.sliceIndexMatch()) return;
+
+    const { coordinates } = this.props.annotationsObject.getActiveAnnotation();
 
     const clickPoint = canvasToImage(
       x,
@@ -648,6 +632,10 @@ export class SplineCanvas extends Component<Props, State> {
   isActive = (): boolean =>
     this.props.activeTool === "spline" ||
     this.props.activeTool === "magicspline";
+
+  sliceIndexMatch = (): boolean =>
+    this.props.annotationsObject.getActiveAnnotation().spaceTimeInfo.z ===
+    this.props.sliceIndex;
 
   toggleMode = (): void => {
     if (!this.isActive()) return;

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -466,6 +466,7 @@ export class UserInterface extends Component<Props, State> {
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
               callRedraw={this.state.callRedraw}
+              sliceIndex={this.state.sliceIndex}
             />
 
             {this.slicesData.length > 1 && (

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -107,7 +107,10 @@ export class UserInterface extends Component<Props, State> {
       displayedImage: this.slicesData[0][0] || null,
     };
 
-    this.annotationsObject.addAnnotation(this.state.activeTool);
+    this.annotationsObject.addAnnotation(this.state.activeTool, {
+      z: this.state.sliceIndex,
+      t: 0,
+    });
     this.presetLabels = this.props.presetLabels || [];
     this.imageFileInfo = null;
   }
@@ -336,7 +339,10 @@ export class UserInterface extends Component<Props, State> {
   };
 
   addAnnotation = (): void => {
-    this.annotationsObject.addAnnotation(this.state.activeTool);
+    this.annotationsObject.addAnnotation(this.state.activeTool, {
+      z: this.state.sliceIndex,
+      t: 0,
+    });
     this.setState({
       activeAnnotationID: this.annotationsObject.getActiveAnnotationID(),
     });
@@ -374,14 +380,16 @@ export class UserInterface extends Component<Props, State> {
     to match the active tool. */
     if (this.annotationsObject.isActiveAnnotationEmpty()) {
       this.annotationsObject.setActiveAnnotationToolbox(this.state.activeTool);
+      this.annotationsObject.setSpaceTimeInfo(this.state.sliceIndex);
     }
   };
 
-  handleToolboxChange =
-    (panel: string) =>
-    (event: ChangeEvent, isExpanded: boolean): void => {
-      this.setState({ expanded: isExpanded ? panel : false });
-    };
+  handleToolboxChange = (panel: string) => (
+    event: ChangeEvent,
+    isExpanded: boolean
+  ): void => {
+    this.setState({ expanded: isExpanded ? panel : false });
+  };
 
   clearActiveAnnotation = (): void => {
     this.annotationsObject.setAnnotationCoordinates([]);
@@ -396,7 +404,10 @@ export class UserInterface extends Component<Props, State> {
       {
         sliceIndex: value,
       },
-      this.mixChannels
+      () => {
+        this.reuseEmptyAnnotation();
+        this.mixChannels();
+      }
     );
   };
 
@@ -444,6 +455,7 @@ export class UserInterface extends Component<Props, State> {
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
               callRedraw={this.state.callRedraw}
+              sliceIndex={this.state.sliceIndex}
             />
 
             <PaintbrushCanvas

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -384,12 +384,11 @@ export class UserInterface extends Component<Props, State> {
     }
   };
 
-  handleToolboxChange = (panel: string) => (
-    event: ChangeEvent,
-    isExpanded: boolean
-  ): void => {
-    this.setState({ expanded: isExpanded ? panel : false });
-  };
+  handleToolboxChange =
+    (panel: string) =>
+    (event: ChangeEvent, isExpanded: boolean): void => {
+      this.setState({ expanded: isExpanded ? panel : false });
+    };
 
   clearActiveAnnotation = (): void => {
     this.annotationsObject.setAnnotationCoordinates([]);

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -107,10 +107,7 @@ export class UserInterface extends Component<Props, State> {
       displayedImage: this.slicesData[0][0] || null,
     };
 
-    this.annotationsObject.addAnnotation(this.state.activeTool, {
-      z: this.state.sliceIndex,
-      t: 0,
-    });
+    this.annotationsObject.addAnnotation(this.state.activeTool);
     this.presetLabels = this.props.presetLabels || [];
     this.imageFileInfo = null;
   }
@@ -339,10 +336,8 @@ export class UserInterface extends Component<Props, State> {
   };
 
   addAnnotation = (): void => {
-    this.annotationsObject.addAnnotation(this.state.activeTool, {
-      z: this.state.sliceIndex,
-      t: 0,
-    });
+    this.annotationsObject.addAnnotation(this.state.activeTool);
+    this.annotationsObject.setSplineSpaceTimeInfo(this.state.sliceIndex);
     this.setState({
       activeAnnotationID: this.annotationsObject.getActiveAnnotationID(),
     });
@@ -380,7 +375,7 @@ export class UserInterface extends Component<Props, State> {
     to match the active tool. */
     if (this.annotationsObject.isActiveAnnotationEmpty()) {
       this.annotationsObject.setActiveAnnotationToolbox(this.state.activeTool);
-      this.annotationsObject.setSpaceTimeInfo(this.state.sliceIndex);
+      this.annotationsObject.setSplineSpaceTimeInfo(this.state.sliceIndex);
     }
   };
 
@@ -391,7 +386,7 @@ export class UserInterface extends Component<Props, State> {
     };
 
   clearActiveAnnotation = (): void => {
-    this.annotationsObject.setAnnotationCoordinates([]);
+    this.annotationsObject.setSplineCoordinates([]);
     this.annotationsObject.setAnnotationBrushStrokes([]);
     this.setState((prevState) => ({
       callRedraw: prevState.callRedraw + 1,


### PR DESCRIPTION
# Description

Adds:

- When annotating 3D images, the z-value (or slice index) gets added to the annotations object; 
- Only the annotations for the slice selected are displayed.

closes #134

# Dependency changes

No

# Testing

No

# Documentation

N/A


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
