### PR TITLE
Annotation methods

### DIFF
--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -12,7 +12,7 @@ loadImage("zebrafish-heart.jpg").then(
       document.getElementById("react-container")
     );
   },
-  (e) => {
+  () => {
     ReactDOM.render(
       <UserInterface />,
       document.getElementById("react-container")

--- a/package-lock.json
+++ b/package-lock.json
@@ -2646,9 +2646,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
-      "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -2742,13 +2742,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz",
-      "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz",
+      "integrity": "sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.24.0",
-        "@typescript-eslint/scope-manager": "4.24.0",
+        "@typescript-eslint/experimental-utils": "4.25.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -2789,15 +2789,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz",
-      "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
+      "integrity": "sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/typescript-estree": "4.24.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/typescript-estree": "4.25.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -2813,14 +2813,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.24.0.tgz",
-      "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.25.0.tgz",
+      "integrity": "sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/typescript-estree": "4.24.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/typescript-estree": "4.25.0",
         "debug": "^4.1.1"
       },
       "engines": {
@@ -2840,13 +2840,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
-      "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz",
+      "integrity": "sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/visitor-keys": "4.24.0"
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/visitor-keys": "4.25.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -2857,9 +2857,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz",
-      "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz",
+      "integrity": "sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -2870,13 +2870,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz",
-      "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz",
+      "integrity": "sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/visitor-keys": "4.24.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/visitor-keys": "4.25.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -2912,12 +2912,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz",
-      "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz",
+      "integrity": "sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/types": "4.25.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -4566,9 +4566,9 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.5.tgz",
-      "integrity": "sha512-bH6QQacvSRtLX0lycAOs43S173n+lfXxB5cx4FjVkTLw5tAEwk5bxNLbkt5K1iETd5KxazRx70GpqOxsuwKiFA==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.6.tgz",
+      "integrity": "sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==",
       "dev": true,
       "dependencies": {
         "icss-utils": "^5.1.0",
@@ -5106,9 +5106,9 @@
       "dev": true
     },
     "node_modules/dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.2.tgz",
+      "integrity": "sha512-qH/MS6fDOeNBTsF3k/v/SrwaXlDeewxgddXGUUfwauEBZkz7u59oF+3ZNSzcZeCuPWOfkqmcAnXW1gliiFW+1A==",
       "dev": true,
       "dependencies": {
         "ip": "^1.1.0",
@@ -5244,9 +5244,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.735",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.735.tgz",
-      "integrity": "sha512-cp7MWzC3NseUJV2FJFgaiesdrS+A8ZUjX5fLAxdRlcaPDkaPGFplX930S5vf84yqDp4LjuLdKouWuVOTwUfqHQ==",
+      "version": "1.3.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz",
+      "integrity": "sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -6623,9 +6623,9 @@
       }
     },
     "node_modules/faye-websocket": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
       "dependencies": {
         "websocket-driver": ">=0.5.1"
@@ -18138,9 +18138,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
-      "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A==",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.1.tgz",
+      "integrity": "sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -18236,13 +18236,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.24.0.tgz",
-      "integrity": "sha512-qbCgkPM7DWTsYQGjx9RTuQGswi+bEt0isqDBeo+CKV0953zqI0Tp7CZ7Fi9ipgFA6mcQqF4NOVNwS/f2r6xShw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz",
+      "integrity": "sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.24.0",
-        "@typescript-eslint/scope-manager": "4.24.0",
+        "@typescript-eslint/experimental-utils": "4.25.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -18263,55 +18263,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.24.0.tgz",
-      "integrity": "sha512-IwTT2VNDKH1h8RZseMH4CcYBz6lTvRoOLDuuqNZZoThvfHEhOiZPQCow+5El3PtyxJ1iDr6UXZwYtE3yZQjhcw==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz",
+      "integrity": "sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/typescript-estree": "4.24.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/typescript-estree": "4.25.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.24.0.tgz",
-      "integrity": "sha512-dj1ZIh/4QKeECLb2f/QjRwMmDArcwc2WorWPRlB8UNTZlY1KpTVsbX7e3ZZdphfRw29aTFUSNuGB8w9X5sS97w==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.25.0.tgz",
+      "integrity": "sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.24.0",
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/typescript-estree": "4.24.0",
+        "@typescript-eslint/scope-manager": "4.25.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/typescript-estree": "4.25.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.24.0.tgz",
-      "integrity": "sha512-9+WYJGDnuC9VtYLqBhcSuM7du75fyCS/ypC8c5g7Sdw7pGL4NDTbeH38eJPfzIydCHZDoOgjloxSAA3+4l/zsA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz",
+      "integrity": "sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/visitor-keys": "4.24.0"
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/visitor-keys": "4.25.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.24.0.tgz",
-      "integrity": "sha512-tkZUBgDQKdvfs8L47LaqxojKDE+mIUmOzdz7r+u+U54l3GDkTpEbQ1Jp3cNqqAU9vMUCBA1fitsIhm7yN0vx9Q==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.25.0.tgz",
+      "integrity": "sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.24.0.tgz",
-      "integrity": "sha512-kBDitL/by/HK7g8CYLT7aKpAwlR8doshfWz8d71j97n5kUa5caHWvY0RvEUEanL/EqBJoANev8Xc/mQ6LLwXGA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz",
+      "integrity": "sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.24.0",
-        "@typescript-eslint/visitor-keys": "4.24.0",
+        "@typescript-eslint/types": "4.25.0",
+        "@typescript-eslint/visitor-keys": "4.25.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -18331,12 +18331,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.24.0.tgz",
-      "integrity": "sha512-4ox1sjmGHIxjEDBnMCtWFFhErXtKA1Ec0sBpuz0fqf3P+g3JFGyTxxbF06byw0FRsPnnbq44cKivH7Ks1/0s6g==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz",
+      "integrity": "sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.24.0",
+        "@typescript-eslint/types": "4.25.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -19652,9 +19652,9 @@
       }
     },
     "css-loader": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.5.tgz",
-      "integrity": "sha512-bH6QQacvSRtLX0lycAOs43S173n+lfXxB5cx4FjVkTLw5tAEwk5bxNLbkt5K1iETd5KxazRx70GpqOxsuwKiFA==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.6.tgz",
+      "integrity": "sha512-0wyN5vXMQZu6BvjbrPdUJvkCzGEO24HC7IS7nW4llc6BBFC+zwR9CKtYGv63Puzsg10L/o12inMY5/2ByzfD6w==",
       "dev": true,
       "requires": {
         "icss-utils": "^5.1.0",
@@ -20066,9 +20066,9 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.2.tgz",
+      "integrity": "sha512-qH/MS6fDOeNBTsF3k/v/SrwaXlDeewxgddXGUUfwauEBZkz7u59oF+3ZNSzcZeCuPWOfkqmcAnXW1gliiFW+1A==",
       "dev": true,
       "requires": {
         "ip": "^1.1.0",
@@ -20195,9 +20195,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.735",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.735.tgz",
-      "integrity": "sha512-cp7MWzC3NseUJV2FJFgaiesdrS+A8ZUjX5fLAxdRlcaPDkaPGFplX930S5vf84yqDp4LjuLdKouWuVOTwUfqHQ==",
+      "version": "1.3.738",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.738.tgz",
+      "integrity": "sha512-vCMf4gDOpEylPSLPLSwAEsz+R3ShP02Y3cAKMZvTqule3XcPp7tgc/0ESI7IS6ZeyBlGClE50N53fIOkcIVnpw==",
       "dev": true
     },
     "emittery": {
@@ -21265,9 +21265,9 @@
       }
     },
     "faye-websocket": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-      "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "dev": true,
       "requires": {
         "websocket-driver": ">=0.5.1"

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -46,6 +46,9 @@ export class Annotations {
     );
   };
 
+  getSplineLength = (): number =>
+    this.data[this.activeAnnotationID].spline.coordinates.length;
+
   isActiveAnnotationEmpty = (): boolean =>
     // Check whether the active annotation object contains any
     // paintbrush or spline annotations.

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -40,11 +40,10 @@ export class Annotations {
   getSplineForActiveAnnotation = (): Spline =>
     this.data[this.activeAnnotationID].spline;
 
-  getSplineCoordinates = (): Array<XYPoint> => {
-    return JSON.parse(
+  getSplineCoordinates = (): Array<XYPoint> =>
+    JSON.parse(
       JSON.stringify(this.data[this.activeAnnotationID].spline.coordinates)
-    );
-  };
+    ) as Array<XYPoint>;
 
   getSplineLength = (): number =>
     this.data[this.activeAnnotationID].spline.coordinates.length;
@@ -55,7 +54,8 @@ export class Annotations {
     this.data[this.activeAnnotationID].spline.coordinates.length === 0 &&
     this.data[this.activeAnnotationID].brushStrokes.length === 0;
 
-  getAllAnnotations = (): Annotation[] => JSON.parse(JSON.stringify(this.data)); // deep copy to ensure no modification without audit logging
+  getAllAnnotations = (): Annotation[] =>
+    JSON.parse(JSON.stringify(this.data)) as Annotation[]; // deep copy to ensure no modification without audit logging
 
   getAllSplines = (z: number): Array<[Spline, number]> => {
     // returns an array of [spline, index] pairs for all splines at the given z-index.

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -90,16 +90,16 @@ export class Annotations {
     this.activeAnnotationID = id;
   };
 
-  setSplineCoordinates = (newCoordinates: XYPoint[]): void => {
-    this.data[this.activeAnnotationID].spline.coordinates = newCoordinates;
-  };
-
   addBrushStroke = (newBrushStroke: BrushStroke): void => {
     this.data[this.activeAnnotationID].brushStrokes.push(newBrushStroke);
   };
 
   clearBrushStrokes = (): void => {
     this.data[this.activeAnnotationID].brushStrokes = [];
+  };
+
+  clearSplineCoordinates = (): void => {
+    this.data[this.activeAnnotationID].spline.coordinates = [];
   };
 
   addSplinePoint = (point: XYPoint): void => {

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -62,7 +62,8 @@ export class Annotations {
     // index needed for identifying the active spline
     const annotations = this.data.filter(
       (annotation: Annotation) =>
-        (annotation.toolbox === "spline" || annotation.toolbox === "magic") &&
+        (annotation.toolbox === "spline" ||
+          annotation.toolbox === "magicspline") &&
         annotation.spline.spaceTimeInfo.z === z
     );
     return annotations.map((annotation: Annotation, i) => [

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -60,16 +60,19 @@ export class Annotations {
   getAllSplines = (z: number): Array<[Spline, number]> => {
     // returns an array of [spline, index] pairs for all splines at the given z-index.
     // index needed for identifying the active spline
-    const annotations = this.data.filter(
-      (annotation: Annotation) =>
+    const splines: Array<[Spline, number]> = [];
+
+    this.data.forEach((annotation, i) => {
+      if (
         (annotation.toolbox === "spline" ||
           annotation.toolbox === "magicspline") &&
         annotation.spline.spaceTimeInfo.z === z
-    );
-    return annotations.map((annotation: Annotation, i) => [
-      annotation.spline,
-      i,
-    ]);
+      ) {
+        splines.push([annotation.spline, i]);
+      }
+    });
+
+    return splines;
   };
 
   length = (): number => this.data.length;

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -30,6 +30,16 @@ export class Annotations {
       }) - 1;
   };
 
+  deleteActiveAnnotation = (): void => {
+    this.data.splice(this.activeAnnotationID, 1);
+    if (this.activeAnnotationID >= this.data.length) {
+      this.activeAnnotationID = this.data.length - 1; // necessary if we delete the one on the end
+    }
+    if (this.data.length === 0) {
+      this.addAnnotation("paintbrush"); // re-create a new empty annotation if we delete the last one (toolbox will be re-assigned by reuseEmptyAnnotation if necessary)
+    }
+  };
+
   getLabels = (): string[] => this.data[this.activeAnnotationID].labels;
 
   getActiveAnnotationID = (): number => this.activeAnnotationID;

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -106,6 +106,10 @@ export class Annotations {
     this.data[this.activeAnnotationID].spline.coordinates.push(point);
   };
 
+  deleteSplinePoint = (idx: number): void => {
+    this.data[this.activeAnnotationID].spline.coordinates.splice(idx, 1);
+  };
+
   updateSplinePoint = (newX: number, newY: number, index: number): void => {
     this.data[this.activeAnnotationID].spline.coordinates[index] = {
       x: newX,

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -104,7 +104,13 @@ export class Annotations {
   };
 
   addBrushStroke = (newBrushStroke: BrushStroke): void => {
-    this.data[this.activeAnnotationID].brushStrokes.push(newBrushStroke);
+    if (
+      ["paintbrush", "eraser"].includes(
+        this.data[this.activeAnnotationID].toolbox
+      )
+    ) {
+      this.data[this.activeAnnotationID].brushStrokes.push(newBrushStroke);
+    }
   };
 
   clearBrushStrokes = (): void => {
@@ -116,7 +122,13 @@ export class Annotations {
   };
 
   addSplinePoint = (point: XYPoint): void => {
-    this.data[this.activeAnnotationID].spline.coordinates.push(point);
+    if (
+      ["spline", "magicspline"].includes(
+        this.data[this.activeAnnotationID].toolbox
+      )
+    ) {
+      this.data[this.activeAnnotationID].spline.coordinates.push(point);
+    }
   };
 
   deleteSplinePoint = (idx: number): void => {

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -30,6 +30,25 @@ export class Annotations {
       }) - 1;
   };
 
+  getLabels = (): string[] => this.data[this.activeAnnotationID].labels;
+
+  getActiveAnnotationID = (): number => this.activeAnnotationID;
+
+  getActiveAnnotation = (): Annotation => this.data[this.activeAnnotationID];
+
+  getSplineForActiveAnnotation = (): Spline =>
+    this.data[this.activeAnnotationID].spline;
+
+  isActiveAnnotationEmpty = (): boolean =>
+    // Check whether the active annotation object contains any
+    // paintbrush or spline annotations.
+    this.data[this.activeAnnotationID].spline.coordinates.length === 0 &&
+    this.data[this.activeAnnotationID].brushStrokes.length === 0;
+
+  getAllAnnotations = (): Annotation[] => this.data;
+
+  length = (): number => this.data.length;
+
   addLabel = (newLabel: string): void => {
     if (!this.data[this.activeAnnotationID].labels.includes(newLabel)) {
       this.data[this.activeAnnotationID].labels.push(newLabel);
@@ -41,17 +60,6 @@ export class Annotations {
       this.activeAnnotationID
     ].labels.filter((label) => label !== existingLabel);
   };
-
-  getLabels = (): string[] => this.data[this.activeAnnotationID].labels;
-
-  getActiveAnnotationID = (): number => this.activeAnnotationID;
-
-  getActiveAnnotation = (): Annotation => this.data[this.activeAnnotationID];
-
-  getSplineForActiveAnnotation = (): Spline =>
-    this.data[this.activeAnnotationID].spline;
-
-  length = (): number => this.data.length;
 
   setActiveAnnotationID = (id: number): void => {
     this.activeAnnotationID = id;
@@ -68,14 +76,6 @@ export class Annotations {
   setActiveAnnotationToolbox = (newToolbox: string): void => {
     this.data[this.activeAnnotationID].toolbox = newToolbox;
   };
-
-  isActiveAnnotationEmpty = (): boolean =>
-    // Check whether the active annotation object contains any
-    // paintbrush or spline annotations.
-    this.data[this.activeAnnotationID].spline.coordinates.length === 0 &&
-    this.data[this.activeAnnotationID].brushStrokes.length === 0;
-
-  getAllAnnotations = (): Annotation[] => this.data;
 
   setSplineSpaceTimeInfo = (z?: number, t?: number): void => {
     // Set space and time data for spline of active annotation.

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -26,6 +26,7 @@ interface Props extends CanvasProps {
   brushRadius: number;
   callRedraw: number;
   sliceIndex: number;
+  setUIActiveAnnotationID: (id: number) => void;
 }
 
 interface Brush {
@@ -419,6 +420,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
       const selectedBrushStroke = this.clickNearBrushStroke(imageX, imageY);
       if (selectedBrushStroke !== null) {
         this.props.annotationsObject.setActiveAnnotationID(selectedBrushStroke);
+        this.props.setUIActiveAnnotationID(selectedBrushStroke);
         this.drawAllStrokes();
       }
     }
@@ -533,6 +535,7 @@ export const PaintbrushCanvas = (
       brushRadius={paintbrush.brushRadius}
       callRedraw={props.callRedraw}
       sliceIndex={props.sliceIndex}
+      setUIActiveAnnotationID={props.setUIActiveAnnotationID}
     />
   );
 };

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -189,19 +189,17 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     context: CanvasRenderingContext2D,
     isActive = true
   ): void => {
-    const points = imagePoints.map(
-      (point): XYPoint => {
-        const { x, y } = imageToCanvas(
-          point.x,
-          point.y,
-          this.props.displayedImage.width,
-          this.props.displayedImage.height,
-          this.props.scaleAndPan,
-          this.props.canvasPositionAndSize
-        );
-        return { x, y };
-      }
-    );
+    const points = imagePoints.map((point): XYPoint => {
+      const { x, y } = imageToCanvas(
+        point.x,
+        point.y,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
+        this.props.scaleAndPan,
+        this.props.canvasPositionAndSize
+      );
+      return { x, y };
+    });
 
     function midPointBetween(p1: XYPoint, p2: XYPoint) {
       return {
@@ -267,7 +265,8 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     // Draw strokes on active layer whiles showing existing paintbrush layers
 
     // Get active annotation ID
-    const activeAnnotationID = this.props.annotationsObject.getActiveAnnotationID();
+    const activeAnnotationID =
+      this.props.annotationsObject.getActiveAnnotationID();
 
     // Clear paintbrush canvas
     context.clearRect(0, 0, context.canvas.width, context.canvas.height);
@@ -362,17 +361,17 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
   saveLine = (radius = 20): void => {
     if (this.points.length < 2) return;
 
-    const { brushStrokes } = this.props.annotationsObject.getActiveAnnotation();
+    let color = this.props.annotationsObject.getActiveAnnotationColor();
     // Do we already have a colour for this layer?
-    const color =
-      brushStrokes?.[0]?.brush.color ||
+    color =
+      color ||
       getRGBAString(
         palette[
           this.props.annotationsObject.getActiveAnnotationID() % palette.length
         ]
       );
 
-    brushStrokes.push({
+    this.props.annotationsObject.addBrushStroke({
       coordinates: [...this.points],
       spaceTimeInfo: { z: this.props.sliceIndex, t: 0 },
       brush: {

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -361,28 +361,28 @@ export class SplineCanvas extends Component<Props, State> {
   clickNearSpline = (imageX: number, imageY: number): number => {
     // Check if point clicked (in image space) is near an existing spline.
     // If true, return annotation index, otherwise return null.
-    const annotations = this.props.annotationsObject.getAllAnnotations();
 
-    for (let i = 0; i < annotations.length; i += 1) {
-      if (
-        annotations[i].spline.spaceTimeInfo.z === this.props.sliceIndex &&
-        annotations[i].toolbox === "spline"
-      ) {
-        const { spline } = annotations[i];
-        // For each pair of points, check is point clicked is near the line segment
-        // having for end points two consecutive points in the spline.
-        for (let j = 1; j < spline.coordinates.length; j += 1) {
-          if (
-            this.isClickNearLineSegment(
-              { x: imageX, y: imageY },
-              spline.coordinates[j - 1],
-              spline.coordinates[j]
-            )
+    const splines = this.props.annotationsObject.getAllSplines(
+      this.props.sliceIndex
+    );
+    splines.forEach(([spline, index]) => {
+      // index here is the index of the annotation this spline is from among all annotations,
+      // not the index within `splines`
+
+      // For each pair of points, check if point clicked is near the line segment
+      // having for end points two consecutive points in the spline:
+      for (let j = 1; j < spline.coordinates.length; j += 1) {
+        if (
+          this.isClickNearLineSegment(
+            { x: imageX, y: imageY },
+            spline.coordinates[j - 1],
+            spline.coordinates[j]
           )
-            return i;
-        }
+        )
+          return index;
       }
-    }
+    });
+
     return null;
   };
 
@@ -625,7 +625,6 @@ export class SplineCanvas extends Component<Props, State> {
       }
     }
     this.props.annotationsObject.insertSplinePoint(newPointIndex, { x, y }); // Add new point to the coordinates array
-    this.props.annotationsObject.setSplineCoordinates(coordinates); // Save new coordinates inside active annotation
   };
 
   getCursor = (): Cursor => {

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -343,7 +343,8 @@ export class SplineCanvas extends Component<Props, State> {
       } else if (this.state.mode === Mode.draw && !isClosed) {
         // Add coordinates to the current spline
         this.props.annotationsObject.addSplinePoint({ x: imageX, y: imageY });
-        this.selectedPointIndex = coordinates.length - 1;
+        this.selectedPointIndex =
+          this.props.annotationsObject.getSplineLength() - 1;
       }
     }
 
@@ -532,7 +533,7 @@ export class SplineCanvas extends Component<Props, State> {
         this.gradientImage = calculateSobel(this.props.displayedImage);
       }
       this.props.annotationsObject.addSplinePoint(clickPoint);
-      this.snapToGradient(coordinates.length - 1);
+      this.snapToGradient(this.props.annotationsObject.getSplineLength() - 1);
       this.isDragging = true;
       this.drawAllSplines();
     } else {
@@ -568,7 +569,7 @@ export class SplineCanvas extends Component<Props, State> {
         y: clickPoint.y,
       });
       this.snapToGradient(
-        coordinates.length - 1,
+        this.props.annotationsObject.getSplineLength() - 1,
         25 / this.props.scaleAndPan.scale
       );
     } else {
@@ -577,7 +578,7 @@ export class SplineCanvas extends Component<Props, State> {
         this.props.annotationsObject.updateSplinePoint(
           clickPoint.x,
           clickPoint.y,
-          coordinates.length - 1
+          this.props.annotationsObject.getSplineLength() - 1
         );
       }
 

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -53,7 +53,7 @@ export class SplineCanvas extends Component<Props, State> {
 
   private selectedPointIndex: number;
 
-  private isDragging: boolean;
+  private isMouseDown: boolean;
 
   private gradientImage: ImageData;
 
@@ -62,7 +62,7 @@ export class SplineCanvas extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
     this.selectedPointIndex = -1;
-    this.isDragging = false;
+    this.isMouseDown = false;
     this.numberOfMoves = 0;
     this.state = { mode: Mode.draw, isActive: false };
   }
@@ -534,19 +534,19 @@ export class SplineCanvas extends Component<Props, State> {
       }
       this.props.annotationsObject.addSplinePoint(clickPoint);
       this.snapToGradient(this.props.annotationsObject.getSplineLength() - 1);
-      this.isDragging = true;
+      this.isMouseDown = true;
       this.drawAllSplines();
     } else {
       const nearPoint = this.clickNearPoint(clickPoint, coordinates);
       if (nearPoint !== -1) {
         this.selectedPointIndex = nearPoint;
-        this.isDragging = true;
+        this.isMouseDown = true;
       }
     }
   };
 
   onMouseMove = (x: number, y: number): void => {
-    if (!this.isDragging) return;
+    if (!this.isMouseDown) return;
 
     this.numberOfMoves += 1;
 
@@ -572,7 +572,7 @@ export class SplineCanvas extends Component<Props, State> {
         this.props.annotationsObject.getSplineLength() - 1,
         25 / this.props.scaleAndPan.scale
       );
-    } else {
+    } else if (this.state.mode !== Mode.magic) {
       // If dragging first point, update also last
       if (this.selectedPointIndex === 0 && this.isClosed(coordinates)) {
         this.props.annotationsObject.updateSplinePoint(
@@ -595,7 +595,7 @@ export class SplineCanvas extends Component<Props, State> {
 
   onMouseUp = (): void => {
     // Works as part of drag and drop for points.
-    this.isDragging = false;
+    this.isMouseDown = false;
   };
 
   isClosed = (splineVector: XYPoint[]): boolean =>

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -258,7 +258,7 @@ export class SplineCanvas extends Component<Props, State> {
       this.setState({ mode: Mode.draw });
     }
 
-    this.selectedPointIndex -= 1;
+    this.selectedPointIndex = Math.max(0, this.selectedPointIndex - 1);
     this.drawAllSplines();
   };
 

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -236,25 +236,25 @@ export class SplineCanvas extends Component<Props, State> {
       }
 
       // Delete x,y point at selected index
-      coordinates.splice(this.selectedPointIndex, 1);
+      this.props.annotationsObject.deleteSplinePoint(this.selectedPointIndex);
 
       // If selected index is first index, delete also point at last index
       if (this.selectedPointIndex === 0) {
-        if (coordinates.length === 1) {
+        if (this.props.annotationsObject.getSplineLength() === 1) {
           this.props.annotationsObject.setSplineCoordinates([]);
         } else {
           this.props.annotationsObject.updateSplinePoint(
-            coordinates[0].x,
-            coordinates[0].y,
-            coordinates.length - 1
+            coordinates[1].x, // coordinates is outdated here due to deleteSplinePoint; coordinates[1] is therefore coordinates[0] now that we've deleted the previous first point
+            coordinates[1].y,
+            this.props.annotationsObject.getSplineLength() - 1
           );
         }
       }
     } else {
       // Delete x,y point at selected index
-      coordinates.splice(this.selectedPointIndex, 1);
+      this.props.annotationsObject.deleteSplinePoint(this.selectedPointIndex);
     }
-    if (coordinates.length === 0) {
+    if (this.props.annotationsObject.getSplineLength() === 0) {
       this.setState({ mode: Mode.draw });
     }
 

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode, Component } from "react";
 import { BaseCanvas, CanvasProps as BaseProps } from "@/baseCanvas";
 import { Annotations } from "@/annotation";
 import { canvasToImage, imageToCanvas } from "@/transforms";
-import { Annotation, XYPoint } from "@/annotation/interfaces";
+import { XYPoint } from "@/annotation/interfaces";
 
 import {
   main as mainColor,

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -365,9 +365,12 @@ export class SplineCanvas extends Component<Props, State> {
     const splines = this.props.annotationsObject.getAllSplines(
       this.props.sliceIndex
     );
-    splines.forEach(([spline, index]) => {
+    for (let i = 0; i < splines.length; i += 1) {
       // index here is the index of the annotation this spline is from among all annotations,
       // not the index within `splines`
+
+      const [spline, index] = splines[i];
+      // here `i` is the index of the spline in `splines`, while `index` is the index of the spline in all annotations
 
       // For each pair of points, check if point clicked is near the line segment
       // having for end points two consecutive points in the spline:
@@ -381,7 +384,7 @@ export class SplineCanvas extends Component<Props, State> {
         )
           return index;
       }
-    });
+    }
 
     return null;
   };

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -19,6 +19,7 @@ interface Props extends BaseProps {
   annotationsObject: Annotations;
   callRedraw: number;
   sliceIndex: number;
+  setUIActiveAnnotationID: (id: number) => void;
 }
 enum Mode {
   draw,
@@ -353,6 +354,7 @@ export class SplineCanvas extends Component<Props, State> {
       const selectedSpline = this.clickNearSpline(imageX, imageY);
       if (selectedSpline !== null) {
         this.props.annotationsObject.setActiveAnnotationID(selectedSpline);
+        this.props.setUIActiveAnnotationID(selectedSpline);
       }
     }
 

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -241,7 +241,7 @@ export class SplineCanvas extends Component<Props, State> {
       // If selected index is first index, delete also point at last index
       if (this.selectedPointIndex === 0) {
         if (this.props.annotationsObject.getSplineLength() === 1) {
-          this.props.annotationsObject.setSplineCoordinates([]);
+          this.props.annotationsObject.clearSplineCoordinates();
         } else {
           this.props.annotationsObject.updateSplinePoint(
             coordinates[1].x, // coordinates is outdated here due to deleteSplinePoint; coordinates[1] is therefore coordinates[0] now that we've deleted the previous first point

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -390,6 +390,11 @@ export class UserInterface extends Component<Props, State> {
 
   clearActiveAnnotation = (): void => {
     this.annotationsObject.deleteActiveAnnotation();
+    if (this.annotationsObject.length() === 1) {
+      // if we delete the last annotation, annotationsObject will make a new one with the paintbrush toolbox
+      // (since it doesn't know which tool is active), so we set the toolbox correctly here:
+      this.annotationsObject.setActiveAnnotationToolbox(this.state.activeTool);
+    }
     this.setState((prevState) => ({
       callRedraw: prevState.callRedraw + 1,
     }));

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -389,8 +389,7 @@ export class UserInterface extends Component<Props, State> {
     };
 
   clearActiveAnnotation = (): void => {
-    this.annotationsObject.clearSplineCoordinates();
-    this.annotationsObject.clearBrushStrokes();
+    this.annotationsObject.deleteActiveAnnotation();
     this.setState((prevState) => ({
       callRedraw: prevState.callRedraw + 1,
     }));
@@ -616,7 +615,7 @@ export class UserInterface extends Component<Props, State> {
             <SplineUI
               expanded={
                 this.state.expanded === "spline-toolbox" ||
-                ["spline"].includes(this.state.activeTool)
+                ["spline", "magicspline"].includes(this.state.activeTool)
               }
               activeTool={this.state.activeTool}
               onChange={this.handleToolboxChange("spline-toolbox")}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -438,15 +438,6 @@ export class UserInterface extends Component<Props, State> {
               annotations={this.annotationsObject.getAllAnnotations()}
               imageFileInfo={this.imageFileInfo}
             />
-            <Button
-              onClick={() => {
-                const t0 = performance.now();
-                this.annotationsObject.getSplineCoordinates();
-                alert(performance.now() - t0);
-              }}
-            >
-              HELLO
-            </Button>
           </Toolbar>
         </AppBar>
         <Toolbar />

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -390,7 +390,7 @@ export class UserInterface extends Component<Props, State> {
 
   clearActiveAnnotation = (): void => {
     this.annotationsObject.setSplineCoordinates([]);
-    this.annotationsObject.setAnnotationBrushStrokes([]);
+    this.annotationsObject.clearBrushStrokes();
     this.setState((prevState) => ({
       callRedraw: prevState.callRedraw + 1,
     }));
@@ -438,6 +438,15 @@ export class UserInterface extends Component<Props, State> {
               annotations={this.annotationsObject.getAllAnnotations()}
               imageFileInfo={this.imageFileInfo}
             />
+            <Button
+              onClick={() => {
+                const t0 = performance.now();
+                this.annotationsObject.getSplineCoordinates();
+                alert(performance.now() - t0);
+              }}
+            >
+              HELLO
+            </Button>
           </Toolbar>
         </AppBar>
         <Toolbar />

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -389,7 +389,7 @@ export class UserInterface extends Component<Props, State> {
     };
 
   clearActiveAnnotation = (): void => {
-    this.annotationsObject.setSplineCoordinates([]);
+    this.annotationsObject.clearSplineCoordinates();
     this.annotationsObject.clearBrushStrokes();
     this.setState((prevState) => ({
       callRedraw: prevState.callRedraw + 1,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -464,6 +464,9 @@ export class UserInterface extends Component<Props, State> {
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
               callRedraw={this.state.callRedraw}
               sliceIndex={this.state.sliceIndex}
+              setUIActiveAnnotationID={(id) => {
+                this.setState({ activeAnnotationID: id });
+              }}
             />
 
             <PaintbrushCanvas
@@ -475,6 +478,9 @@ export class UserInterface extends Component<Props, State> {
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
               callRedraw={this.state.callRedraw}
               sliceIndex={this.state.sliceIndex}
+              setUIActiveAnnotationID={(id) => {
+                this.setState({ activeAnnotationID: id });
+              }}
             />
 
             {this.slicesData.length > 1 && (


### PR DESCRIPTION
# Description

Since we need to log every change to the `annotationsObject`, we need all changes to be done via methods on that object which can log their effects. Previously, particularly in `SplineCanvas`, we were making most of our changes by getting data structures out of `annotationsObject` by reference (e.g. `const { coordinates } = this.props.annotationsObject.getActiveAnnotation();`), and modifying them directly. If we kept doing that then we'd have to manually log all of these changes and it'd get messy and there would be bugs. So I've added a bunch of methods to the `Annotations` class like `addSplinePoint` and `addBrushStroke`, and removed methods like `getActiveAnnotation` where possible (there are a couple of methods like that that I couldn't remove, so instead I had them return a copy of a data structure rather than a reference to it, so they can't be used to modify the internal state of `annotationsObject`).

I think I've fixed all the bugs this introduced, but if someone could mess around with the paintbrush and spline tools and try to break them, that'd be much appreciated.

relates #151 

# Dependency changes

N/A

# Testing

N/A

# Documentation

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
