### PR TITLE
Using decorators for audit logging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,13 @@ module.exports = {
               "`with` is disallowed in strict mode because it makes code impossible to predict and optimize.",
           },
         ],
+        "no-param-reassign": [
+          "error",
+          {
+            props: true,
+            ignorePropertyModificationsFor: ["descriptor", "context"], // Decorators
+          },
+        ],
       },
     },
     {

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -18,7 +18,7 @@ function log(
 ): void {
   const targetMethod = descriptor.value;
 
-  descriptor.value = (...args) => {
+  descriptor.value = function auditWrapper(...args) {
     (this as Annotations).addAudit(propertyKey, args);
 
     return targetMethod.apply(this, args);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "baseUrl": "./",
     "paths": {
       "@/*": ["src/*"]
-    }
+    },
+    "experimentalDecorators": true,
   },
   "include": [
     "typings/**/*",


### PR DESCRIPTION
# Description

As @ChasNelson1990 mentioned on Thursday, there was a lot of logging code duplication in the `Annotations` class, with `this.audit.push(...` duplicated in every set/modify method. TypeScript has experimental support for decorators (which have been in Python since 2003, just sayin), and it's apparently stable enough that people use it in production (I think Angular uses them a lot). Decorators are higher-order functions (i.e. functions that take a function and return a new function) that let you add new functionality to your functions. It's like a function that gets applied to whichever functions you choose, at compile time, to modify them in some way. So I've used them to add the logging functionality to all the set/modify methods, since so many of the guides out there use logging as an example use case for decorators. This allows us to remove all the duplicated code, which hopefully means less chance for error now.

Things I had to do to make this work:
1. enable `experimentalDeccorators` in tsconfig.json
2. disable eslint on the decorator function (it really doesn't like `any` and I'm pretty sure you need a lot of `any` typed stuff to use decorators, at least this kind of decorator
3. convert all the set/modify methods from arrow functions to regular methods, since arrow functions are technically properties, not methods, so I couldn't apply method decorators to them

It's also worth mentioning that the decorator will only log arguments that are actually _passed_ to a method; if an argument is omitted because the parameter has a default value, then the default value that gets used will not be logged. This is fine so long as we don't change any of the default values.

# Testing

`testAudit` reports everything is still fine, I haven't been able to break it yet. Need to make this into a proper test though (see #163).

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
