### PR TITLE
chore: Add callback for saving annotations data

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -27,6 +27,7 @@ import {
   KeyboardArrowUp,
   ExpandMore,
   Backup,
+  Save,
 } from "@material-ui/icons";
 
 import { ImageFileInfo } from "@gliff-ai/upload/typings";
@@ -77,6 +78,7 @@ interface Props {
   imageFileInfo?: ImageFileInfo;
   annotationsObject?: Annotations;
   presetLabels?: string[];
+  saveAnnotationsCallback?: (annotationsObject: Annotations) => void;
 }
 
 export class UserInterface extends Component<Props, State> {
@@ -438,6 +440,18 @@ export class UserInterface extends Component<Props, State> {
               annotations={this.annotationsObject.getAllAnnotations()}
               imageFileInfo={this.imageFileInfo}
             />
+            {this.props.saveAnnotationsCallback && (
+              <Tooltip title="Save annotations data">
+                <Button
+                  aria-label="save"
+                  onClick={() =>
+                    this.props.saveAnnotationsCallback(this.annotationsObject)
+                  }
+                >
+                  <Save />
+                </Button>
+              </Tooltip>
+            )}
           </Toolbar>
         </AppBar>
         <Toolbar />


### PR DESCRIPTION
# Description
Adds a callback for saving annotations data (prop and save button). 
Note: This is part of gliff-ai/dominate#54.

# Dependency changes
No

# Testing
No

# Documentation
N/A


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
