### PR TITLE
Select anything

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,5 @@ dist
 .*.js
 webpack*.js
 *.spec.ts
+
+coverage/

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -312,6 +312,8 @@ export class Annotations {
     b: XYPoint, // line segment endpoint 2
     threshold = 12
   ): boolean => {
+    // returns true if point p is within a capsule with endpoints a and b, and radius `threshold`
+    // math from https://iquilezles.org/www/articles/distfunctions/distfunctions.htm
     const pa: XYPoint = { x: p.x - a.x, y: p.y - a.y };
     const ba: XYPoint = { x: b.x - a.x, y: b.y - a.y };
     let h = (pa.x * ba.x + pa.y * ba.y) / (ba.x ** 2 + ba.y ** 2);

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -243,14 +243,6 @@ export class Annotations {
     // If true, return annotation index, otherwise return null.
     // If more than one annotation at clicked point, select first drawn.
 
-    const isClickNearPoint = (
-      point: XYPoint,
-      point1: XYPoint,
-      radius: number
-    ): boolean =>
-      Math.abs(point.x - point1.x) < radius &&
-      Math.abs(point.y - point1.y) < radius;
-
     for (let i = 0; i < this.data.length; i += 1) {
       if (this.data[i].toolbox === "paintbrush") {
         let finalIndex = null;
@@ -318,7 +310,7 @@ export class Annotations {
     p: XYPoint, // test point
     a: XYPoint, // line segment endpoint 1
     b: XYPoint, // line segment endpoint 2
-    threshold: number = 12
+    threshold = 12
   ): boolean => {
     const pa: XYPoint = { x: p.x - a.x, y: p.y - a.y };
     const ba: XYPoint = { x: b.x - a.x, y: b.y - a.y };

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -258,11 +258,12 @@ export class Annotations {
         this.data[i].brushStrokes.forEach(
           ({ spaceTimeInfo, coordinates, brush }) => {
             if (spaceTimeInfo.z === sliceIndex) {
-              coordinates.forEach((point: XYPoint) => {
+              for (let j = 0; j < coordinates.length - 1; j += 1) {
                 if (
-                  isClickNearPoint(
+                  this.isClickNearLineSegment(
                     { x: imageX, y: imageY },
-                    point,
+                    coordinates[j],
+                    coordinates[j + 1],
                     brush.radius
                   )
                 ) {
@@ -270,7 +271,7 @@ export class Annotations {
                   // finalIndex will be reset to null.
                   finalIndex = brush.type === "paint" ? i : null;
                 }
-              });
+              }
             }
           }
         );
@@ -288,35 +289,6 @@ export class Annotations {
     // Check if point clicked (in image space) is near an existing spline.
     // If true, return annotation index, otherwise return null.
 
-    const isClickNearLineSegment = (
-      point: XYPoint,
-      point1: XYPoint,
-      point2: XYPoint
-    ): boolean => {
-      // Check if a XYpoint belongs to the line segment with endpoints XYpoint 1 and XYpoint 2.
-      const dx = point.x - point1.x;
-      const dy = point.y - point1.y;
-      const dxLine = point2.x - point1.x;
-      const dyLine = point2.y - point1.y;
-      const distance = 700;
-      // Use the cross-product to check whether the XYpoint lies on the line passing
-      // through XYpoint 1 and XYpoint 2.
-      const crossProduct = dx * dyLine - dy * dxLine;
-      // If the XYpoint is exactly on the line the cross-product is zero. Here we set a threshold
-      // based on ease of use, to accept points that are close enough to the spline.
-      if (Math.abs(crossProduct) > distance) return false;
-
-      // Check if the point is on the segment (i.e., between point 1 and point 2).
-      if (Math.abs(dxLine) >= Math.abs(dyLine)) {
-        return dxLine > 0
-          ? point1.x <= point.x && point.x <= point2.x
-          : point2.x <= point.x && point.x <= point1.x;
-      }
-      return dyLine > 0
-        ? point1.y <= point.y && point.y <= point2.y
-        : point2.y <= point.y && point.y <= point1.y;
-    };
-
     const splines = this.getAllSplines(sliceIndex);
     for (let i = 0; i < splines.length; i += 1) {
       // index here is the index of the annotation this spline is from among all annotations,
@@ -329,7 +301,7 @@ export class Annotations {
       // having for end points two consecutive points in the spline:
       for (let j = 1; j < spline.coordinates.length; j += 1) {
         if (
-          isClickNearLineSegment(
+          this.isClickNearLineSegment(
             { x: imageX, y: imageY },
             spline.coordinates[j - 1],
             spline.coordinates[j]
@@ -340,5 +312,19 @@ export class Annotations {
     }
 
     return null;
+  };
+
+  isClickNearLineSegment = (
+    p: XYPoint, // test point
+    a: XYPoint, // line segment endpoint 1
+    b: XYPoint, // line segment endpoint 2
+    threshold: number = 12
+  ): boolean => {
+    const pa: XYPoint = { x: p.x - a.x, y: p.y - a.y };
+    const ba: XYPoint = { x: b.x - a.x, y: b.y - a.y };
+    let h = (pa.x * ba.x + pa.y * ba.y) / (ba.x ** 2 + ba.y ** 2);
+    h = Math.max(Math.min(h, 1), 0); // clamp between 0 and 1
+    const r = Math.sqrt((pa.x - h * ba.x) ** 2 + (pa.y - h * ba.y) ** 2);
+    return r < threshold;
   };
 }

--- a/src/annotation/interfaces.ts
+++ b/src/annotation/interfaces.ts
@@ -38,3 +38,9 @@ export interface PositionAndSize {
   width?: number;
   height?: number;
 }
+
+export interface AuditAction {
+  method: string;
+  args: string;
+  timestamp: number; // milliseconds since epoch
+}

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -9,7 +9,7 @@ export const keybindings = {
   Enter: "spline.changeSplineModeToEdit",
   Escape: "spline.deselectPoint",
   "ctrl+KeyC": "spline.closeLoop",
-  "ctrl+KeyA": "spline-paintbrush.toggleMode",
+  "ctrl+KeyA": "ui.toggleMode",
   "ctrl+ArrowLeft": "ui.previousAnnotation",
   "ctrl+ArrowRight": "ui.nextAnnotation",
 } as Readonly<{

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -11,6 +11,7 @@ import { Annotations } from "@/annotation";
 import { canvasToImage, imageToCanvas } from "@/transforms";
 import { XYPoint } from "@/annotation/interfaces";
 import { Tool, Tools } from "@/tools";
+import { Mode } from "@/ui";
 
 import {
   main as mainColor,
@@ -22,7 +23,8 @@ import {
 import { usePaintbrushStore } from "./Store";
 
 interface Props extends CanvasProps {
-  brushType: string;
+  activeTool: string;
+  mode: Mode;
   annotationsObject: Annotations;
   brushRadius: number;
   callRedraw: number;
@@ -37,19 +39,13 @@ interface Brush {
   color: string; // rgb(a) string
 }
 
-enum Mode {
-  draw,
-  select,
-}
-
 interface State {
   hideBackCanvas: boolean;
-  mode: Mode;
 }
 
 // Here we define the methods that are exposed to be called by keyboard shortcuts
 // We should maybe namespace them so we don't get conflicting methods across toolboxes.
-export const events = ["saveLine", "toggleMode"] as const;
+export const events = ["saveLine"] as const;
 
 interface Event extends CustomEvent {
   type: typeof events[number];
@@ -58,13 +54,13 @@ interface Event extends CustomEvent {
 type Cursor = "crosshair" | "pointer" | "none" | "not-allowed";
 
 type CursorProps = {
-  brushType: string;
+  activeTool: string;
   brushRadius: number;
   canvasTopAndLeft: { top: number; left: number };
 };
 
 const FauxCursor: React.FC<CursorProps> = ({
-  brushType,
+  activeTool,
   brushRadius,
   canvasTopAndLeft,
 }: CursorProps): ReactElement => {
@@ -87,7 +83,7 @@ const FauxCursor: React.FC<CursorProps> = ({
       id="cursor"
       style={{
         visibility:
-          brushType === "paintbrush" || brushType === "eraser"
+          activeTool === "paintbrush" || activeTool === "eraser"
             ? "visible"
             : "hidden",
         width: brushRadius,
@@ -127,7 +123,6 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
 
     this.state = {
       hideBackCanvas: false,
-      mode: Mode.draw,
     };
   }
 
@@ -172,7 +167,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
       const brush = {
         color: getRGBAString(mainColor),
         radius: this.props.brushRadius,
-        type: this.props.brushType === "paintbrush" ? "paint" : "erase",
+        type: this.props.activeTool === "paintbrush" ? "paint" : "erase",
       } as Brush;
 
       // Draw current points
@@ -306,17 +301,9 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     return brushRadius * imageScalingFactor * 2 * this.props.scaleAndPan.scale;
   };
 
-  toggleMode = (): void => {
-    if (!this.isActive()) return;
-    if (this.state.mode === Mode.draw) {
-      this.setState({ mode: Mode.select });
-    } else {
-      this.setState({ mode: Mode.draw });
-    }
-  };
-
   isActive = (): boolean =>
-    this.props.brushType === "paintbrush" || this.props.brushType === "eraser";
+    this.props.activeTool === "paintbrush" ||
+    this.props.activeTool === "eraser";
 
   saveLine = (radius = 20): void => {
     if (this.points.length < 2) return;
@@ -337,7 +324,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
       brush: {
         color,
         radius,
-        type: this.props.brushType === "paintbrush" ? "paint" : "erase",
+        type: this.props.activeTool === "paintbrush" ? "paint" : "erase",
       },
     });
 
@@ -351,9 +338,9 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
 
   /* *** Mouse events *** */
   onMouseDown = (canvasX: number, canvasY: number): void => {
-    if (this.state.mode === Mode.draw) {
+    if (this.props.mode === Mode.draw) {
       // Start drawing
-      if (this.props.brushType === "eraser") {
+      if (this.props.activeTool === "eraser") {
         // Copy the current BACK strokes to the front canvas
         this.drawAllStrokes(this.interactionCanvas.canvasContext);
         this.setState({ hideBackCanvas: true }, () => {
@@ -366,7 +353,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
 
       // Ensure the initial down position gets added to our line
       this.handlePointerMove(canvasX, canvasY);
-    } else if (this.state.mode === Mode.select) {
+    } else if (this.props.mode === Mode.select) {
       // In select mode a single click allows to select a different paintbrush or spline annotation
       const { x: imageX, y: imageY } = canvasToImage(
         canvasX,
@@ -405,13 +392,13 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
   };
 
   onMouseMove = (canvasX: number, canvasY: number): void => {
-    if (this.state.mode === Mode.draw) {
+    if (this.props.mode === Mode.draw) {
       this.handlePointerMove(canvasX, canvasY);
     }
   };
 
   onMouseUp = (canvasX: number, canvasY: number): void => {
-    if (this.state.mode === Mode.draw) {
+    if (this.props.mode === Mode.draw) {
       // End painting & save painting
       this.isPressing = false;
 
@@ -428,10 +415,10 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
 
   getCursor = (): Cursor => {
     if (
-      this.props.brushType === "paintbrush" ||
-      this.props.brushType === "eraser"
+      this.props.activeTool === "paintbrush" ||
+      this.props.activeTool === "eraser"
     ) {
-      return this.state.mode === Mode.draw ? "none" : "pointer";
+      return this.props.mode === Mode.draw ? "none" : "pointer";
     }
     return "none";
   };
@@ -446,7 +433,7 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
     <>
       {/* this div is basically a fake cursor */}
       <FauxCursor
-        brushType={this.props.brushType}
+        activeTool={this.props.activeTool}
         brushRadius={this.getCanvasBrushRadius(this.props.brushRadius)}
         canvasTopAndLeft={{
           top:
@@ -461,8 +448,8 @@ export class PaintbrushCanvasClass extends Component<Props, State> {
       <div
         style={{
           pointerEvents:
-            this.props.brushType === "paintbrush" ||
-            this.props.brushType === "eraser"
+            this.props.activeTool === "paintbrush" ||
+            this.props.activeTool === "eraser"
               ? "auto"
               : "none",
         }}
@@ -505,7 +492,8 @@ export const PaintbrushCanvas = (
 
   return (
     <PaintbrushCanvasClass
-      brushType={props.brushType}
+      activeTool={props.activeTool}
+      mode={props.mode}
       annotationsObject={props.annotationsObject}
       displayedImage={props.displayedImage}
       scaleAndPan={props.scaleAndPan}

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -325,7 +325,7 @@ export class SplineCanvas extends Component<Props, State> {
           imageY,
           this.props.sliceIndex
         );
-      console.log(selectedSpline, selectedBrushStroke);
+
       if (
         selectedSpline !== null &&
         selectedSpline !== this.props.annotationsObject.getActiveAnnotationID()
@@ -479,7 +479,6 @@ export class SplineCanvas extends Component<Props, State> {
   };
 
   onMouseDown = (x: number, y: number): void => {
-    console.log("SPLINE CANVAS MOUSEDOWN");
     if (!this.isActive()) return;
     if (!this.sliceIndexMatch()) return;
 

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -479,7 +479,6 @@ export class SplineCanvas extends Component<Props, State> {
   };
 
   onMouseDown = (x: number, y: number): void => {
-    if (!this.isActive()) return;
     if (!this.sliceIndexMatch()) return;
 
     const coordinates = this.props.annotationsObject.getSplineCoordinates();
@@ -512,7 +511,6 @@ export class SplineCanvas extends Component<Props, State> {
   };
 
   onMouseMove = (x: number, y: number): void => {
-    if (!this.isActive()) return;
     if (!this.isMouseDown) return;
 
     this.numberOfMoves += 1;
@@ -562,8 +560,6 @@ export class SplineCanvas extends Component<Props, State> {
 
   onMouseUp = (): void => {
     // Works as part of drag and drop for points.
-    if (!this.isActive()) return;
-
     this.isMouseDown = false;
   };
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -467,6 +467,9 @@ export class UserInterface extends Component<Props, State> {
               setUIActiveAnnotationID={(id) => {
                 this.setState({ activeAnnotationID: id });
               }}
+              setActiveTool={(tool: Tool) => {
+                this.setState({ activeTool: tool });
+              }}
             />
 
             <PaintbrushCanvas
@@ -480,6 +483,9 @@ export class UserInterface extends Component<Props, State> {
               sliceIndex={this.state.sliceIndex}
               setUIActiveAnnotationID={(id) => {
                 this.setState({ activeAnnotationID: id });
+              }}
+              setActiveTool={(tool: Tool) => {
+                this.setState({ activeTool: tool });
               }}
             />
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -48,12 +48,21 @@ const CONFIG = {
   PAN_AMOUNT: 20,
 } as const;
 
+export enum Mode {
+  draw,
+  select,
+}
+
 interface Event extends CustomEvent {
   type: typeof events[number];
 }
 
 // Here we define the methods that are exposed to be called by keyboard shortcuts
-export const events = ["nextAnnotation", "previousAnnotation"] as const;
+export const events = [
+  "nextAnnotation",
+  "previousAnnotation",
+  "toggleMode",
+] as const;
 
 interface State {
   scaleAndPan: {
@@ -70,6 +79,7 @@ interface State {
   callRedraw: number;
   sliceIndex: number;
   channels: boolean[];
+  mode: Mode;
 }
 
 interface Props {
@@ -108,6 +118,7 @@ export class UserInterface extends Component<Props, State> {
       channels: [true],
       displayedImage: this.slicesData[0][0] || null,
       activeTool: Tools.paintbrush,
+      mode: Mode.draw,
     };
 
     this.annotationsObject.addAnnotation(this.state.activeTool);
@@ -354,6 +365,14 @@ export class UserInterface extends Component<Props, State> {
     this.cycleActiveAnnotation(false);
   };
 
+  toggleMode = (): void => {
+    if (this.state.mode === Mode.draw) {
+      this.setState({ mode: Mode.select });
+    } else {
+      this.setState({ mode: Mode.draw });
+    }
+  };
+
   cycleActiveAnnotation = (forward = true): void => {
     const data = this.annotationsObject.getAllAnnotations();
     this.setState((prevState) => {
@@ -458,6 +477,7 @@ export class UserInterface extends Component<Props, State> {
             <SplineCanvas
               scaleAndPan={this.state.scaleAndPan}
               activeTool={this.state.activeTool}
+              mode={this.state.mode}
               annotationsObject={this.annotationsObject}
               displayedImage={this.state.displayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
@@ -474,7 +494,8 @@ export class UserInterface extends Component<Props, State> {
 
             <PaintbrushCanvas
               scaleAndPan={this.state.scaleAndPan}
-              brushType={this.state.activeTool}
+              activeTool={this.state.activeTool}
+              mode={this.state.mode}
               annotationsObject={this.annotationsObject}
               displayedImage={this.state.displayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}


### PR DESCRIPTION
# Description

Before we could only select splines when a spline was active, and only select brushstrokes when paintbrush was active, now click-to-select can select anything regardless of which type annotation is active (Ctrl-arrows still cycles through annotations of the same type).

Also re-wrote the code for detecting brushstroke-clicks, so it no longer gets false negatives when you click in between two widely spaced brush coordinate points (which can happen if the brushstroke was drawn with a rapid mouse movement).

Had to move some code out of SplineCanvas and PaintbrushCanvas and into the Annotations class to make this work.

closes #164 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
