### PR TITLE
chore: Update slicesData and annotationsObject when props change

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -136,6 +136,28 @@ export class UserInterface extends Component<Props, State> {
     this.mixChannels();
   };
 
+  componentDidUpdate = (prevProps: Props): void => {
+    if (
+      this.props.slicesData &&
+      prevProps.slicesData !== this.props.slicesData
+    ) {
+      this.slicesData = this.props.slicesData;
+      /* eslint-disable react/no-did-update-set-state */
+      this.setState({
+        displayedImage: this.slicesData[0][0],
+        sliceIndex: 0,
+      });
+      this.imageFileInfo = this.props.imageFileInfo;
+    }
+
+    if (
+      this.props.annotationsObject &&
+      prevProps.annotationsObject !== this.props.annotationsObject
+    ) {
+      this.annotationsObject = this.props.annotationsObject;
+    }
+  };
+
   componentWillUnmount(): void {
     for (const event of events) {
       document.removeEventListener(event, this.handleEvent);


### PR DESCRIPTION
# Description
When Annotate is loaded onto Dominate, D. passes down to A. some data as props (i.e., slicesData, imageFileInfo, annotationsObject). A. should listen for changes in any of these props and update the value of the corresponding objects.
Part of gliff-ai/dominate#54

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
