### PR TITLE
fix: Annotate doesn't load without optional prop slicesData

### DIFF
--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -27,7 +27,7 @@ interface Props extends CanvasProps {
   mode: Mode;
   annotationsObject: Annotations;
   brushRadius: number;
-  callRedraw: number;
+  redraw: number;
   sliceIndex: number;
   setUIActiveAnnotationID: (id: number) => void;
   setActiveTool: (tool: Tool) => void;
@@ -499,7 +499,7 @@ export const PaintbrushCanvas = (
       scaleAndPan={props.scaleAndPan}
       canvasPositionAndSize={props.canvasPositionAndSize}
       brushRadius={paintbrush.brushRadius}
-      callRedraw={props.callRedraw}
+      redraw={props.redraw}
       sliceIndex={props.sliceIndex}
       setUIActiveAnnotationID={props.setUIActiveAnnotationID}
       setActiveTool={props.setActiveTool}

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -20,7 +20,7 @@ interface Props extends BaseProps {
   activeTool: string;
   mode: Mode;
   annotationsObject: Annotations;
-  callRedraw: number;
+  redraw: number;
   sliceIndex: number;
   setUIActiveAnnotationID: (id: number) => void;
   setActiveTool: (tool: Tool) => void;

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -77,7 +77,7 @@ interface State {
   viewportPositionAndSize: Required<PositionAndSize>;
   minimapPositionAndSize: Required<PositionAndSize>;
   expanded: string | boolean;
-  callRedraw: number;
+  redraw: number;
   sliceIndex: number;
   channels: boolean[];
   mode: Mode;
@@ -115,7 +115,7 @@ export class UserInterface extends Component<Props, State> {
       viewportPositionAndSize: { top: 0, left: 0, width: 768, height: 768 },
       minimapPositionAndSize: { top: 0, left: 0, width: 200, height: 200 },
       expanded: "labels-toolbox",
-      callRedraw: 0,
+      redraw: 0,
       sliceIndex: 0,
       channels: [true],
       displayedImage: this.slicesData[0][0] || null,
@@ -155,6 +155,11 @@ export class UserInterface extends Component<Props, State> {
       prevProps.annotationsObject !== this.props.annotationsObject
     ) {
       this.annotationsObject = this.props.annotationsObject;
+      // Restore activeAnnotationID
+      this.annotationsObject.setActiveAnnotationID(
+        this.state.activeAnnotationID
+      );
+      this.callRedraw();
     }
   };
 
@@ -438,8 +443,12 @@ export class UserInterface extends Component<Props, State> {
       // (since it doesn't know which tool is active), so we set the toolbox correctly here:
       this.annotationsObject.setActiveAnnotationToolbox(this.state.activeTool);
     }
+    this.callRedraw();
+  };
+
+  callRedraw = () => {
     this.setState((prevState) => ({
-      callRedraw: prevState.callRedraw + 1,
+      redraw: prevState.redraw + 1,
     }));
   };
 
@@ -518,7 +527,7 @@ export class UserInterface extends Component<Props, State> {
               displayedImage={this.state.displayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
-              callRedraw={this.state.callRedraw}
+              redraw={this.state.redraw}
               sliceIndex={this.state.sliceIndex}
               setUIActiveAnnotationID={(id) => {
                 this.setState({ activeAnnotationID: id });
@@ -536,7 +545,7 @@ export class UserInterface extends Component<Props, State> {
               displayedImage={this.state.displayedImage}
               canvasPositionAndSize={this.state.viewportPositionAndSize}
               setCanvasPositionAndSize={this.setViewportPositionAndSize}
-              callRedraw={this.state.callRedraw}
+              redraw={this.state.redraw}
               sliceIndex={this.state.sliceIndex}
               setUIActiveAnnotationID={(id) => {
                 this.setState({ activeAnnotationID: id });

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -118,7 +118,7 @@ export class UserInterface extends Component<Props, State> {
       redraw: 0,
       sliceIndex: 0,
       channels: [true],
-      displayedImage: this.slicesData[0][0] || null,
+      displayedImage: this.slicesData ? this.slicesData[0][0] : null,
       activeTool: Tools.paintbrush,
       mode: Mode.draw,
     };
@@ -176,6 +176,7 @@ export class UserInterface extends Component<Props, State> {
   };
 
   updatePresetLabels = (label: string): void => {
+    if (!this.state.displayedImage) return;
     function onlyUnique(value: string, index: number, self: string[]) {
       return self.indexOf(value) === index;
     }
@@ -254,6 +255,7 @@ export class UserInterface extends Component<Props, State> {
     // adjust pan such that image borders are not inside the canvas
 
     // calculate how much bigger the image is than the canvas, in canvas space:
+    if (!this.state.displayedImage) return;
     const imageScalingFactor = Math.min(
       this.state.viewportPositionAndSize.width /
         this.state.displayedImage.width,
@@ -354,6 +356,7 @@ export class UserInterface extends Component<Props, State> {
     // the result in this.state.displayedImage
 
     // draw the channels onto a new canvas using additive composition:
+    if (!this.slicesData) return;
     const canvas = document.createElement("canvas");
     const context = canvas.getContext("2d");
     canvas.width = this.slicesData[this.state.sliceIndex][0].width;
@@ -379,6 +382,7 @@ export class UserInterface extends Component<Props, State> {
   };
 
   addAnnotation = (): void => {
+    if (!this.state.displayedImage) return;
     this.annotationsObject.addAnnotation(this.state.activeTool);
     this.annotationsObject.setSplineSpaceTimeInfo(this.state.sliceIndex);
     this.setState({
@@ -512,50 +516,53 @@ export class UserInterface extends Component<Props, State> {
 
         <Grid container spacing={0} justify="center" wrap="nowrap">
           <Grid item style={{ width: "85%", position: "relative" }}>
-            <BackgroundCanvas
-              scaleAndPan={this.state.scaleAndPan}
-              displayedImage={this.state.displayedImage}
-              canvasPositionAndSize={this.state.viewportPositionAndSize}
-              setCanvasPositionAndSize={this.setViewportPositionAndSize}
-            />
+            {this.state.displayedImage && (
+              <>
+                <BackgroundCanvas
+                  scaleAndPan={this.state.scaleAndPan}
+                  displayedImage={this.state.displayedImage}
+                  canvasPositionAndSize={this.state.viewportPositionAndSize}
+                  setCanvasPositionAndSize={this.setViewportPositionAndSize}
+                />
 
-            <SplineCanvas
-              scaleAndPan={this.state.scaleAndPan}
-              activeTool={this.state.activeTool}
-              mode={this.state.mode}
-              annotationsObject={this.annotationsObject}
-              displayedImage={this.state.displayedImage}
-              canvasPositionAndSize={this.state.viewportPositionAndSize}
-              setCanvasPositionAndSize={this.setViewportPositionAndSize}
-              redraw={this.state.redraw}
-              sliceIndex={this.state.sliceIndex}
-              setUIActiveAnnotationID={(id) => {
-                this.setState({ activeAnnotationID: id });
-              }}
-              setActiveTool={(tool: Tool) => {
-                this.setState({ activeTool: tool });
-              }}
-            />
+                <SplineCanvas
+                  scaleAndPan={this.state.scaleAndPan}
+                  activeTool={this.state.activeTool}
+                  mode={this.state.mode}
+                  annotationsObject={this.annotationsObject}
+                  displayedImage={this.state.displayedImage}
+                  canvasPositionAndSize={this.state.viewportPositionAndSize}
+                  setCanvasPositionAndSize={this.setViewportPositionAndSize}
+                  redraw={this.state.redraw}
+                  sliceIndex={this.state.sliceIndex}
+                  setUIActiveAnnotationID={(id) => {
+                    this.setState({ activeAnnotationID: id });
+                  }}
+                  setActiveTool={(tool: Tool) => {
+                    this.setState({ activeTool: tool });
+                  }}
+                />
 
-            <PaintbrushCanvas
-              scaleAndPan={this.state.scaleAndPan}
-              activeTool={this.state.activeTool}
-              mode={this.state.mode}
-              annotationsObject={this.annotationsObject}
-              displayedImage={this.state.displayedImage}
-              canvasPositionAndSize={this.state.viewportPositionAndSize}
-              setCanvasPositionAndSize={this.setViewportPositionAndSize}
-              redraw={this.state.redraw}
-              sliceIndex={this.state.sliceIndex}
-              setUIActiveAnnotationID={(id) => {
-                this.setState({ activeAnnotationID: id });
-              }}
-              setActiveTool={(tool: Tool) => {
-                this.setState({ activeTool: tool });
-              }}
-            />
-
-            {this.slicesData.length > 1 && (
+                <PaintbrushCanvas
+                  scaleAndPan={this.state.scaleAndPan}
+                  activeTool={this.state.activeTool}
+                  mode={this.state.mode}
+                  annotationsObject={this.annotationsObject}
+                  displayedImage={this.state.displayedImage}
+                  canvasPositionAndSize={this.state.viewportPositionAndSize}
+                  setCanvasPositionAndSize={this.setViewportPositionAndSize}
+                  redraw={this.state.redraw}
+                  sliceIndex={this.state.sliceIndex}
+                  setUIActiveAnnotationID={(id) => {
+                    this.setState({ activeAnnotationID: id });
+                  }}
+                  setActiveTool={(tool: Tool) => {
+                    this.setState({ activeTool: tool });
+                  }}
+                />
+              </>
+            )}
+            {this.slicesData && this.slicesData.length > 1 && (
               <div
                 style={{
                   position: "absolute",
@@ -581,22 +588,24 @@ export class UserInterface extends Component<Props, State> {
             )}
           </Grid>
           <Grid item style={{ width: 200, position: "relative" }}>
-            <div style={{ height: 200 }}>
-              <BackgroundCanvas
-                scaleAndPan={{ x: 0, y: 0, scale: 1 }}
-                displayedImage={this.state.displayedImage}
-                canvasPositionAndSize={this.state.minimapPositionAndSize}
-                setCanvasPositionAndSize={this.setMinimapPositionAndSize}
-              />
-              <MinimapCanvas
-                displayedImage={this.state.displayedImage}
-                scaleAndPan={this.state.scaleAndPan}
-                setScaleAndPan={this.setScaleAndPan}
-                canvasPositionAndSize={this.state.viewportPositionAndSize}
-                minimapPositionAndSize={this.state.minimapPositionAndSize}
-                setMinimapPositionAndSize={this.setMinimapPositionAndSize}
-              />
-            </div>
+            {this.state.displayedImage && (
+              <div style={{ height: 200 }}>
+                <BackgroundCanvas
+                  scaleAndPan={{ x: 0, y: 0, scale: 1 }}
+                  displayedImage={this.state.displayedImage}
+                  canvasPositionAndSize={this.state.minimapPositionAndSize}
+                  setCanvasPositionAndSize={this.setMinimapPositionAndSize}
+                />
+                <MinimapCanvas
+                  displayedImage={this.state.displayedImage}
+                  scaleAndPan={this.state.scaleAndPan}
+                  setScaleAndPan={this.setScaleAndPan}
+                  canvasPositionAndSize={this.state.viewportPositionAndSize}
+                  minimapPositionAndSize={this.state.minimapPositionAndSize}
+                  setMinimapPositionAndSize={this.setMinimapPositionAndSize}
+                />
+              </div>
+            )}
 
             <Grid container justify="center">
               <ButtonGroup size="small" style={{ margin: "5px" }}>


### PR DESCRIPTION
# Description

Fix bug #179, and a few other things linked to gliff-ai/dominate#54 (i.e., trigger a re-render when the prop annotationsObject changes and set activeAnnotationID for annotationsObject to the value saved as a state).

closes #179 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
