### PR TITLE
feat: Add full-screen loader

### DIFF
--- a/src/decorators/index.tsx
+++ b/src/decorators/index.tsx
@@ -1,0 +1,1 @@
+export { pageLoading } from "./progress";

--- a/src/decorators/progress.tsx
+++ b/src/decorators/progress.tsx
@@ -1,0 +1,25 @@
+import { UI } from "../ui";
+
+interface Descriptor extends Omit<PropertyDescriptor, "value"> {
+  value?: (...args: unknown[]) => unknown;
+}
+
+function pageLoading(
+  target: UI,
+  propertyKey: string,
+  descriptor: Descriptor
+): void {
+  const targetMethod = descriptor.value;
+
+  descriptor.value = async function decoratorWrapper(...args) {
+    const setIsLoading = (this as UI).props?.setIsLoading;
+
+    await targetMethod.apply(this, args);
+
+    if (typeof setIsLoading === "function") {
+      setIsLoading(false);
+    }
+  };
+}
+
+export { pageLoading };

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -34,6 +34,7 @@ import { tooltips } from "@/components/tooltips";
 import { BaseIconButton } from "@/components/BaseIconButton";
 import { BaseSlider, Config } from "@/components/BaseSlider";
 import { BaseButton } from "@/components/BaseButton";
+import { pageLoading } from "@/decorators";
 
 const logger = console;
 
@@ -158,6 +159,7 @@ interface Props extends WithStyles<typeof styles> {
   presetLabels?: string[];
   saveAnnotationsCallback?: (annotationsObject: Annotations) => void;
   showAppBar: boolean;
+  setIsLoading?: (isLoading: boolean) => void;
 }
 
 class UserInterface extends Component<Props, State> {
@@ -208,7 +210,8 @@ class UserInterface extends Component<Props, State> {
     this.refBtnsPopovers = {};
   }
 
-  componentDidMount = (): void => {
+  @pageLoading
+  componentDidMount(): void {
     document.addEventListener("keydown", keydownListener);
 
     for (const event of events) {
@@ -218,7 +221,7 @@ class UserInterface extends Component<Props, State> {
 
     const { clientHeight: height, clientWidth: width } = this.canvasContainer;
     this.setViewportPositionAndSize({ top: 0, left: 0, width, height });
-  };
+  }
 
   componentDidUpdate = (prevProps: Props): void => {
     if (
@@ -555,7 +558,7 @@ class UserInterface extends Component<Props, State> {
     this.callRedraw();
   };
 
-  callRedraw = () => {
+  callRedraw = (): void => {
     this.setState((prevState) => ({
       redraw: prevState.redraw + 1,
     }));
@@ -623,7 +626,7 @@ class UserInterface extends Component<Props, State> {
     this.props.saveAnnotationsCallback(this.annotationsObject);
   };
 
-  isTyping = () =>
+  isTyping = (): boolean =>
     // Added to prevent single-key shortcuts that are also valid text input
     // to get triggered during text input.
     this.refBtnsPopovers[tooltips.labels.name] === this.state.anchorElement;
@@ -964,4 +967,6 @@ class UserInterface extends Component<Props, State> {
     );
   };
 }
+
+export { UserInterface as UI };
 export default withStyles(styles)(UserInterface);


### PR DESCRIPTION
# Description
Add decorator to stop rendering a loading spinner as soon as annotate mounts (works only when annotate is loaded onto dominate).

gliff-ai/roadmap/issues/54, full-screen spinner for page load.

# Dependency changes
No

# Testing
No

# Documentation
No

# Migrations (if applicable)

Have any database migrations been committed as part of this pull request?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
