### PR TITLE
feat: add lasso splines

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   ],
   "scripts": {
     "build": "webpack --progress --config webpack.build.js",
-    "format": "npx --no-install prettier --write src/{**,.}/*.ts*",
-    "prettier": "npx --no-install prettier -c src/{**,.}/*.ts*",
+    "format": "npx --no-install prettier --write src/{**,.}/{**,.}/*.ts*",
+    "prettier": "npx --no-install prettier -c src/{**,.}/{**,.}/*.ts*",
     "lint": "npm run lint:ts && npm run prettier",
-    "lint:ts": "npx eslint src/{**,.}/*.ts*",
+    "lint:ts": "npx eslint src/{**,.}/{**,.}/*.ts*",
     "serve": "webpack serve --config webpack.build.js",
     "test": "jest --coverage --passWithNoTests",
     "prepublishOnly": "rm -r dist/; webpack --progress --config webpack.package.js"

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -99,8 +99,7 @@ export class Annotations {
 
     this.data.forEach((annotation, i) => {
       if (
-        (annotation.toolbox === "spline" ||
-          annotation.toolbox === "magicspline") &&
+        annotation.toolbox === "spline" &&
         annotation.spline.spaceTimeInfo.z === z
       ) {
         splines.push([annotation.spline, i]);
@@ -154,11 +153,7 @@ export class Annotations {
 
   @log
   addSplinePoint(point: XYPoint): void {
-    if (
-      ["spline", "magicspline"].includes(
-        this.data[this.activeAnnotationID].toolbox
-      )
-    ) {
+    if (this.data[this.activeAnnotationID].toolbox === "spline") {
       this.data[this.activeAnnotationID].spline.coordinates.push(point);
     }
   }
@@ -287,7 +282,7 @@ export class Annotations {
       // here `i` is the index of the spline in `splines`, while `index` is the index of the spline in all annotations
 
       // For each pair of points, check if point clicked is near the line segment
-      // having for end points two consecutive points in the spline:
+      // having for end points two consecutive points in the spline
       for (let j = 1; j < spline.coordinates.length; j += 1) {
         if (
           this.isClickNearLineSegment(

--- a/src/components/tools.ts
+++ b/src/components/tools.ts
@@ -2,7 +2,6 @@ export const Tools = {
   paintbrush: "paintbrush",
   eraser: "eraser",
   spline: "spline",
-  magicspline: "magicspline",
 } as const;
 
 export type Tool = typeof Tools[keyof typeof Tools];

--- a/src/components/tooltips.ts
+++ b/src/components/tooltips.ts
@@ -67,10 +67,20 @@ const tooltips: ToolTips = {
     icon: require(`@/assets/splines-icon.svg`) as string,
     shortcut: "S",
   },
+  lassospline: {
+    name: "Lasso Spline",
+    icon: require(`@/assets/magic-spline-icon.svg`) as string,
+    shortcut: "O",
+  },
   magicspline: {
     name: "Magic Spline",
     icon: require(`@/assets/magic-spline-icon.svg`) as string,
     shortcut: "M",
+  },
+  closespline: {
+    name: "Close Active Spline",
+    icon: require(`@/assets/magic-spline-icon.svg`) as string,
+    shortcut: "L",
   },
   contrast: {
     name: "Contrast",
@@ -80,17 +90,18 @@ const tooltips: ToolTips = {
   brightness: {
     name: "Brightness",
     icon: require(`@/assets/brightness-icon.svg`) as string,
-    shortcut: `/`,
+    shortcut: "/",
   },
   channels: {
     name: "Channels",
     icon: require(`@/assets/channels-icon.svg`) as string,
-    shortcut: `C`,
+    shortcut: "C",
   },
   labels: {
     name: "Annotation Label",
     icon: require(`@/assets/annotation-label-icon.svg`) as string,
-    shortcut: "L",
+    shortcut: "CTRL",
+    shortcutSymbol: "L",
   },
   download: {
     name: "Download annotations",

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -21,7 +21,7 @@ export const keybindings = {
   Enter: "spline.changeSplineModeToEdit",
   Escape: "spline.deselectPoint",
   "ctrl+KeyS": "ui.saveAnnotations",
-  "ctrl+KeyC": "spline.closeLoop",
+  "ctrl+KeyC": "spline.closeSpline",
   "ctrl+ArrowLeft": "ui.previousAnnotation",
   "ctrl+ArrowRight": "ui.nextAnnotation",
   "alt+Equal": "minimap.handleDrawerOpen",

--- a/src/toolboxes/paintbrush/Submenu.tsx
+++ b/src/toolboxes/paintbrush/Submenu.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles(() =>
   })
 );
 
-const PaintbrushUI = (props: Props): ReactElement => {
+const Submenu = (props: Props): ReactElement => {
   const [paintbrush, setPaintbrush] = usePaintbrushStore();
   const classes = useStyles();
 
@@ -48,4 +48,4 @@ const PaintbrushUI = (props: Props): ReactElement => {
   );
 };
 
-export { PaintbrushUI };
+export { Submenu };

--- a/src/toolboxes/paintbrush/index.ts
+++ b/src/toolboxes/paintbrush/index.ts
@@ -1,4 +1,4 @@
 export { PaintbrushCanvas } from "./Canvas";
-export { PaintbrushUI } from "./UI";
+export { Submenu } from "./Submenu";
 export { Toolbar as PaintbrushToolbar } from "./Toolbar";
 export { BrushStroke } from "./interfaces";

--- a/src/toolboxes/spline/Store.ts
+++ b/src/toolboxes/spline/Store.ts
@@ -1,0 +1,12 @@
+import { tooltips } from "@/components/tooltips";
+import { createStore } from "@/store";
+
+// types will include: spline, lasso, magic and box
+interface SplineData {
+  splineType: string;
+}
+
+const defaultSpline: SplineData = { splineType: tooltips.spline.name };
+
+// we've created store with initial value. This can now be used anywhere and will share the value.
+export const [useSplineStore] = createStore(defaultSpline);

--- a/src/toolboxes/spline/Submenu.tsx
+++ b/src/toolboxes/spline/Submenu.tsx
@@ -26,9 +26,10 @@ const Submenu = (props: Props): ReactElement => {
   }
 
   function closeSpline() {
-    document.dispatchEvent(new CustomEvent("closeSpline", { detail: "spline" }));
+    document.dispatchEvent(
+      new CustomEvent("closeSpline", { detail: "spline" })
+    );
   }
-
 
   return (
     <Popover
@@ -36,27 +37,27 @@ const Submenu = (props: Props): ReactElement => {
       anchorEl={props.anchorElement}
       onClose={props.onClose}
     >
-        <ButtonGroup size="small" id="spline-toolbar">
-      <BaseIconButton
-        tooltip={tooltips.spline}
-        onClick={selectSpline}
-        fill={spline.splineType === tooltips.spline.name}
-      />
-      <BaseIconButton
-        tooltip={tooltips.lassospline}
-        onClick={selectLassoSpline}
-        fill={spline.splineType === tooltips.lassospline.name}
-      />
-      {/* <BaseIconButton
+      <ButtonGroup size="small" id="spline-toolbar">
+        <BaseIconButton
+          tooltip={tooltips.spline}
+          onClick={selectSpline}
+          fill={spline.splineType === tooltips.spline.name}
+        />
+        <BaseIconButton
+          tooltip={tooltips.lassospline}
+          onClick={selectLassoSpline}
+          fill={spline.splineType === tooltips.lassospline.name}
+        />
+        {/* <BaseIconButton
         tooltip={tooltips.magicspline}
         onClick={selectMagicSpline}
         fill={spline.splineType === tooltips.magicspline.name}
       /> */}
-      <BaseIconButton
-        tooltip={tooltips.closespline}
-        onClick={closeSpline}
-        fill={false}
-      />
+        <BaseIconButton
+          tooltip={tooltips.closespline}
+          onClick={closeSpline}
+          fill={false}
+        />
       </ButtonGroup>
     </Popover>
   );

--- a/src/toolboxes/spline/Submenu.tsx
+++ b/src/toolboxes/spline/Submenu.tsx
@@ -1,0 +1,65 @@
+import { ReactElement, MouseEvent } from "react";
+import { ButtonGroup, Popover } from "@material-ui/core";
+import { BaseIconButton } from "@/components/BaseIconButton";
+import { tooltips } from "@/components/tooltips";
+import { useSplineStore } from "./Store";
+
+interface Props {
+  isOpen: boolean;
+  anchorElement: HTMLButtonElement | null;
+  onClose: (event: MouseEvent) => void;
+}
+
+const Submenu = (props: Props): ReactElement => {
+  const [spline, setSpline] = useSplineStore();
+
+  function selectSpline() {
+    setSpline({ splineType: tooltips.spline.name });
+  }
+
+  function selectLassoSpline() {
+    setSpline({ splineType: tooltips.lassospline.name });
+  }
+
+  function selectMagicSpline() {
+    setSpline({ splineType: tooltips.magicspline.name });
+  }
+
+  function closeSpline() {
+    document.dispatchEvent(new CustomEvent("closeSpline", { detail: "spline" }));
+  }
+
+
+  return (
+    <Popover
+      open={props.isOpen}
+      anchorEl={props.anchorElement}
+      onClose={props.onClose}
+    >
+        <ButtonGroup size="small" id="spline-toolbar">
+      <BaseIconButton
+        tooltip={tooltips.spline}
+        onClick={selectSpline}
+        fill={spline.splineType === tooltips.spline.name}
+      />
+      <BaseIconButton
+        tooltip={tooltips.lassospline}
+        onClick={selectLassoSpline}
+        fill={spline.splineType === tooltips.lassospline.name}
+      />
+      {/* <BaseIconButton
+        tooltip={tooltips.magicspline}
+        onClick={selectMagicSpline}
+        fill={spline.splineType === tooltips.magicspline.name}
+      /> */}
+      <BaseIconButton
+        tooltip={tooltips.closespline}
+        onClick={closeSpline}
+        fill={false}
+      />
+      </ButtonGroup>
+    </Popover>
+  );
+};
+
+export { Submenu };

--- a/src/toolboxes/spline/Toolbar.tsx
+++ b/src/toolboxes/spline/Toolbar.tsx
@@ -9,47 +9,47 @@ interface Event extends CustomEvent {
 }
 
 interface Props {
-    buttonClicked: string;
-    setButtonClicked: (buttonName: string) => void;
-    activateTool: (activeTool: string) => void;
-    handleOpen: (
-      event?: MouseEvent
-    ) => (anchorElement?: HTMLButtonElement) => void;
-    isTyping: () => boolean;
-  }
+  buttonClicked: string;
+  setButtonClicked: (buttonName: string) => void;
+  activateTool: (activeTool: string) => void;
+  handleOpen: (
+    event?: MouseEvent
+  ) => (anchorElement?: HTMLButtonElement) => void;
+  isTyping: () => boolean;
+}
 
 class Toolbar extends Component<Props> {
-    private refSplinePopover: HTMLButtonElement;
-  
-    constructor(props: Props) {
-      super(props);
-      this.refSplinePopover = null;
-    }
-  
-    componentDidMount = (): void => {
-      for (const event of events) {
-        document.addEventListener(event, this.handleEvent);
-      }
-    };
-  
-    componentWillUnmount(): void {
-      for (const event of events) {
-        document.removeEventListener(event, this.handleEvent);
-      }
-    }
-  
-    handleEvent = (event: Event): void => {
-      if (event.detail === "spline") {
-        this[event.type]?.call(this);
-      }
-    };
+  private refSplinePopover: HTMLButtonElement;
 
-    selectSpline = (): void => {
-        if (this.props.isTyping()) return;
-        this.props.handleOpen()(this.refSplinePopover);
-        this.props.setButtonClicked(tooltips.spline.name);
-        this.props.activateTool("spline");
-      };
+  constructor(props: Props) {
+    super(props);
+    this.refSplinePopover = null;
+  }
+
+  componentDidMount = (): void => {
+    for (const event of events) {
+      document.addEventListener(event, this.handleEvent);
+    }
+  };
+
+  componentWillUnmount(): void {
+    for (const event of events) {
+      document.removeEventListener(event, this.handleEvent);
+    }
+  }
+
+  handleEvent = (event: Event): void => {
+    if (event.detail === "spline") {
+      this[event.type]?.call(this);
+    }
+  };
+
+  selectSpline = (): void => {
+    if (this.props.isTyping()) return;
+    this.props.handleOpen()(this.refSplinePopover);
+    this.props.setButtonClicked(tooltips.spline.name);
+    this.props.activateTool("spline");
+  };
 
   render = (): ReactElement => (
     <>

--- a/src/toolboxes/spline/Toolbar.tsx
+++ b/src/toolboxes/spline/Toolbar.tsx
@@ -1,50 +1,55 @@
-import { Component, ReactElement } from "react";
+import { Component, ReactElement, MouseEvent } from "react";
 import { BaseIconButton } from "@/components/BaseIconButton";
 import { tooltips } from "@/components/tooltips";
 
-const events = ["selectSpline", "selectMagicspline"] as const;
+const events = ["selectSpline"] as const;
 
 interface Event extends CustomEvent {
   type: typeof events[number];
 }
 
 interface Props {
-  buttonClicked: string;
-  setButtonClicked: (buttonName: string) => void;
-  activateTool: (activeTool: string) => void;
-  isTyping: () => boolean;
-}
-
-class Toolbar extends Component<Props> {
-  componentDidMount = (): void => {
-    for (const event of events) {
-      document.addEventListener(event, this.handleEvent);
-    }
-  };
-
-  componentWillUnmount(): void {
-    for (const event of events) {
-      document.removeEventListener(event, this.handleEvent);
-    }
+    buttonClicked: string;
+    setButtonClicked: (buttonName: string) => void;
+    activateTool: (activeTool: string) => void;
+    handleOpen: (
+      event?: MouseEvent
+    ) => (anchorElement?: HTMLButtonElement) => void;
+    isTyping: () => boolean;
   }
 
-  handleEvent = (event: Event): void => {
-    if (event.detail === "spline") {
-      this[event.type]?.call(this);
+class Toolbar extends Component<Props> {
+    private refSplinePopover: HTMLButtonElement;
+  
+    constructor(props: Props) {
+      super(props);
+      this.refSplinePopover = null;
     }
-  };
+  
+    componentDidMount = (): void => {
+      for (const event of events) {
+        document.addEventListener(event, this.handleEvent);
+      }
+    };
+  
+    componentWillUnmount(): void {
+      for (const event of events) {
+        document.removeEventListener(event, this.handleEvent);
+      }
+    }
+  
+    handleEvent = (event: Event): void => {
+      if (event.detail === "spline") {
+        this[event.type]?.call(this);
+      }
+    };
 
-  selectSpline = (): void => {
-    if (this.props.isTyping()) return;
-    this.props.setButtonClicked(tooltips.spline.name);
-    this.props.activateTool("spline");
-  };
-
-  selectMagicspline = (): void => {
-    if (this.props.isTyping()) return;
-    this.props.setButtonClicked(tooltips.magicspline.name);
-    this.props.activateTool("magicspline");
-  };
+    selectSpline = (): void => {
+        if (this.props.isTyping()) return;
+        this.props.handleOpen()(this.refSplinePopover);
+        this.props.setButtonClicked(tooltips.spline.name);
+        this.props.activateTool("spline");
+      };
 
   render = (): ReactElement => (
     <>
@@ -52,12 +57,10 @@ class Toolbar extends Component<Props> {
         tooltip={tooltips.spline}
         onClick={this.selectSpline}
         fill={this.props.buttonClicked === tooltips.spline.name}
+        setRefCallback={(ref) => {
+          this.refSplinePopover = ref;
+        }}
       />
-      {/* <BaseIconButton
-        tooltip={tooltips.magicspline}
-        onClick={this.selectMagicspline}
-        fill={this.props.buttonClicked === tooltips.magicspline.name}
-      /> */}
     </>
   );
 }

--- a/src/toolboxes/spline/index.ts
+++ b/src/toolboxes/spline/index.ts
@@ -1,3 +1,4 @@
 export { SplineCanvas, events } from "./Canvas";
+export { Submenu } from "./Submenu";
 export { Toolbar as SplineToolbar } from "./Toolbar";
 export { Spline } from "./interfaces";

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/toolboxes/background";
 import {
   SplineCanvas,
+  Submenu as SplineSubmenu,
   SplineToolbar,
 } from "@/toolboxes/spline";
 import {
@@ -773,6 +774,7 @@ class UserInterface extends Component<Props, State> {
                   buttonClicked={this.state.buttonClicked}
                   setButtonClicked={this.setButtonClicked}
                   activateTool={this.activateTool}
+                  handleOpen={this.handleOpen}
                   isTyping={this.isTyping}
                 />
               </ButtonGroup>
@@ -939,16 +941,14 @@ class UserInterface extends Component<Props, State> {
                 anchorElement={this.state.anchorElement}
                 onClose={this.handleClose}
               />
-              {/* <SplineUI
-              isOpen={
-                this.state.buttonClicked === "Spline" && this.state.popover
-              }
-              anchorElement={this.state.anchorElement}
-              onClick={this.handleRequestClose}
-              onClose={this.handleClose}
-              activeTool={this.state.activeTool}
-              activateTool={this.activateTool}
-            /> */}
+              <SplineSubmenu
+                isOpen={
+                  this.state.buttonClicked === "Spline" &&
+                  Boolean(this.state.anchorElement)
+                }
+                anchorElement={this.state.anchorElement}
+                onClose={this.handleClose}
+              />
             </Grid>
           </Container>
           <MinimapUI

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -20,10 +20,13 @@ import {
   BackgroundUI,
   MinimapUI,
 } from "@/toolboxes/background";
-import { SplineCanvas, SplineToolbar } from "@/toolboxes/spline";
+import {
+  SplineCanvas,
+  SplineToolbar,
+} from "@/toolboxes/spline";
 import {
   PaintbrushCanvas,
-  PaintbrushUI,
+  Submenu as PaintbrushSubmenu,
   PaintbrushToolbar,
 } from "@/toolboxes/paintbrush";
 import { LabelsPopover } from "@/toolboxes/labels";
@@ -928,7 +931,7 @@ class UserInterface extends Component<Props, State> {
                 toggleChannelAtIndex={this.toggleChannelAtIndex}
                 displayedImage={this.state.displayedImage}
               />
-              <PaintbrushUI
+              <PaintbrushSubmenu
                 isOpen={
                   this.state.buttonClicked === "Brush" &&
                   Boolean(this.state.anchorElement)


### PR DESCRIPTION
# Description

1. adds a new lasso spline - basically you drag the mouse and it makes a load of points exactly where you drag (this is different to the 'magic spline' which snaps those points to areas of high gradient and is currently turned off because it works so badly)
2. a spline submenu for picking which type of spline you're using spline/magic/lasso and closing the active spline

Future work:
- [ ] new icons needed (will need some design input from @joshuajames-smith and @ChrisBaidoo), will create issues
- [ ] new docs needed (will need @philhallbio to update the docs when this is merged), will create an issue

# Dependency changes

None

# Testing

None

# Documentation

See above.

# Migrations (if applicable)

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
