### PR TITLE
feat: ability to convert splines to paintbrushes and fill paintbrush strokes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.18.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@gliff-ai/slpf": "^1.1.0",
         "@gliff-ai/upload": "^0.1.4",
         "@material-ui/core": "^4.11.3",
         "@material-ui/icons": "^4.11.2",
         "react-inlinesvg": "^2.3.0",
+        "simplify-js": "^1.2.4",
         "utif": "^3.1.0"
       },
       "devDependencies": {
@@ -1836,6 +1838,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@gliff-ai/slpf": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/slpf/-/slpf-1.1.0.tgz",
+      "integrity": "sha512-hYRrFKFH40tx2XCGMx+SwKm8OMojqYhHgTFregOEa4GNotak3+4ogN1Pg73da2MwX22gLxtL22phPu5qDzyJOg=="
     },
     "node_modules/@gliff-ai/upload": {
       "version": "0.1.20",
@@ -13570,6 +13577,11 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simplify-js": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/simplify-js/-/simplify-js-1.2.4.tgz",
+      "integrity": "sha512-vITfSlwt7h/oyrU42R83mtzFpwYk3+mkH9bOHqq/Qw6n8rtR7aE3NZQ5fbcyCUVVmuMJR6ynsAhOfK2qoah8Jg=="
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -17701,6 +17713,11 @@
           "dev": true
         }
       }
+    },
+    "@gliff-ai/slpf": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/slpf/-/slpf-1.1.0.tgz",
+      "integrity": "sha512-hYRrFKFH40tx2XCGMx+SwKm8OMojqYhHgTFregOEa4GNotak3+4ogN1Pg73da2MwX22gLxtL22phPu5qDzyJOg=="
     },
     "@gliff-ai/upload": {
       "version": "0.1.20",
@@ -26711,6 +26728,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simplify-js": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/simplify-js/-/simplify-js-1.2.4.tgz",
+      "integrity": "sha512-vITfSlwt7h/oyrU42R83mtzFpwYk3+mkH9bOHqq/Qw6n8rtR7aE3NZQ5fbcyCUVVmuMJR6ynsAhOfK2qoah8Jg=="
     },
     "sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -67,10 +67,12 @@
     "react-dom": "^17.0.1"
   },
   "dependencies": {
+    "@gliff-ai/slpf": "^1.1.0",
     "@gliff-ai/upload": "^0.1.4",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "react-inlinesvg": "^2.3.0",
+    "simplify-js": "^1.2.4",
     "utif": "^3.1.0"
   }
 }

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -1,7 +1,7 @@
 import { BoundingBox, BoundingBoxCoordinates } from "@/toolboxes/boundingBox";
 import { BrushStroke } from "@/toolboxes/paintbrush";
 import { Spline } from "@/toolboxes/spline";
-import { Annotation, XYPoint, AuditAction } from "./interfaces";
+import { Annotation, XYPoint, AuditAction, ZTPoint } from "./interfaces";
 
 interface Descriptor extends Omit<PropertyDescriptor, "value"> {
   // Ideally this would be the methods of Annotations
@@ -363,6 +363,30 @@ export class Annotations {
     const r = Math.sqrt((pa.x - h * ba.x) ** 2 + (pa.y - h * ba.y) ** 2);
     return r < distanceThreshold;
   };
+
+
+  getSplineSpaceTimeInfo = (): ZTPoint =>
+    this.data[this.activeAnnotationID].spline?.spaceTimeInfo;
+
+  @log
+  convertSplineToPaintbrush(radius: number): void {
+    const coordinates = this.getSplineCoordinates();
+    const color = this.getActiveAnnotationColor(); // FIXME always green
+    const labels = this.getLabels();
+    const spaceTimeInfo = this.getSplineSpaceTimeInfo();
+    const brushStroke: BrushStroke = {
+      coordinates,
+      spaceTimeInfo,
+      brush: {
+        radius,
+        type: "paint",
+        color,
+      },
+    };
+    this.deleteActiveAnnotation();
+    this.addAnnotation("paintbrush", labels);
+    this.addBrushStroke(brushStroke);
+  }
 
   // AUDIT
   addAudit(method: string, args: unknown): void {

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -364,7 +364,6 @@ export class Annotations {
     return r < distanceThreshold;
   };
 
-
   getSplineSpaceTimeInfo = (): ZTPoint =>
     this.data[this.activeAnnotationID].spline?.spaceTimeInfo;
 
@@ -477,4 +476,11 @@ export class Annotations {
   clearBrushStrokes(): void {
     this.data[this.activeAnnotationID].brushStrokes = [];
   }
+
+  getBrushStrokeCoordinates = (index = 0): Array<XYPoint> =>
+    JSON.parse(
+      JSON.stringify(
+        this.data[this.activeAnnotationID].brushStrokes[index]?.coordinates
+      )
+    ) as Array<XYPoint>;
 }

--- a/src/components/tooltips.ts
+++ b/src/components/tooltips.ts
@@ -62,6 +62,11 @@ const tooltips: ToolTips = {
     icon: require(`@/assets/eraser-icon.svg`) as string,
     shortcut: "E",
   },
+  fillbrush: {
+    name: "Fill Active Brushstroke",
+    icon: require(`@/assets/magic-spline-icon.svg`) as string,
+    shortcut: "F",
+  },
   spline: {
     name: "Spline",
     icon: require(`@/assets/splines-icon.svg`) as string,

--- a/src/components/tooltips.ts
+++ b/src/components/tooltips.ts
@@ -87,6 +87,11 @@ const tooltips: ToolTips = {
     icon: require(`@/assets/magic-spline-icon.svg`) as string,
     shortcut: "L",
   },
+  fillspline: {
+    name: "Fill Active Spline & Convert to Paintbrush",
+    icon: require(`@/assets/magic-spline-icon.svg`) as string,
+    shortcut: "F",
+  },
   boundingBox: {
     name: "Rectangular Bounding Box",
     icon: require(`@/assets/bounding-box-icon.svg`) as string,

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -200,13 +200,6 @@ export class CanvasClass extends Component<Props, State> {
       return { x, y };
     });
 
-    function midPointBetween(p1: XYPoint, p2: XYPoint) {
-      return {
-        x: p1.x + (p2.x - p1.x) / 2,
-        y: p1.y + (p2.y - p1.y) / 2,
-      };
-    }
-
     context.lineJoin = "round";
     context.lineCap = "round";
 
@@ -237,26 +230,17 @@ export class CanvasClass extends Component<Props, State> {
 
     context.lineWidth = this.getCanvasBrushRadius(brush.radius);
 
-    let p1 = points[0];
-    let p2 = points[1];
+    const firstPoint = points[0];
 
-    context.moveTo(p2.x, p2.y);
     context.beginPath();
+    context.moveTo(firstPoint.x, firstPoint.y);
 
-    for (let i = 1, len = points.length; i < len; i += 1) {
-      // we pick the point between pi+1 & pi+2 as the
-      // end point and p1 as our control point
-      const midPoint = midPointBetween(p1, p2);
-
-      context.quadraticCurveTo(p1.x, p1.y, midPoint.x, midPoint.y);
-      p1 = points[i];
-      p2 = points[i + 1];
+    for (let i = 1; i < points.length; i += 1) {
+      // we just use linear connections for now
+      const nextPoint = points[i];
+      context.lineTo(nextPoint.x, nextPoint.y);
     }
 
-    // Draw last line as a straight line while
-    // we wait for the next point to be able to calculate
-    // the bezier control point
-    context.lineTo(p1.x, p1.y);
     context.stroke();
   };
 

--- a/src/toolboxes/paintbrush/Submenu.tsx
+++ b/src/toolboxes/paintbrush/Submenu.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent, ReactElement, MouseEvent } from "react";
 import { createStyles, makeStyles, Popover } from "@material-ui/core";
 import { BaseSlider } from "@/components/BaseSlider";
+import { BaseIconButton } from "@/components/BaseIconButton";
+import { tooltips } from "@/components/tooltips";
 import { Sliders, SLIDER_CONFIG } from "./configSlider";
 import { usePaintbrushStore } from "./Store";
 
@@ -30,6 +32,12 @@ const Submenu = (props: Props): ReactElement => {
     });
   }
 
+  function fillBrush() {
+    document.dispatchEvent(
+      new CustomEvent("fillBrush", { detail: "paintbrush" })
+    );
+  }
+
   return (
     <Popover
       open={props.isOpen}
@@ -44,6 +52,11 @@ const Submenu = (props: Props): ReactElement => {
           showEndValues={false}
         />
       </div>
+      <BaseIconButton
+        tooltip={tooltips.fillbrush}
+        onClick={fillBrush}
+        fill={false}
+      />
     </Popover>
   );
 };

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -30,6 +30,7 @@ export const events = [
   "deleteSelectedPoint",
   "deselectPoint",
   "closeSpline",
+  "fillSpline",
 ] as const;
 
 const mainColor = theme.palette.primary.main;
@@ -412,6 +413,29 @@ class CanvasClass extends Component<Props> {
 
     // add an endpoint that is the same as the startpoint
     this.props.annotationsObject.addSplinePoint(coordinates[0]);
+
+    this.drawAllSplines();
+  };
+
+  fillSpline = (): void => {
+    // Create a new paintbrush annotation that is equivalent to closing and filling the current spline shape
+
+    // check the current annotation is on the current slice
+    if (!this.sliceIndexMatch()) return;
+
+    // convert to paintbrush annotation with diameter=1 pixel
+    // TODO determine radius more cleverly
+    this.props.annotationsObject.convertSplineToPaintbrush(2);
+
+    // call the fill paintbrush function
+    document.dispatchEvent(
+      new CustomEvent("fillBrush", { detail: "paintbrush" })
+    );
+
+    // set the active tool to be the paintbrush
+    document.dispatchEvent(
+      new CustomEvent("selectBrush", { detail: "paintbrush" })
+    );
 
     this.drawAllSplines();
   };

--- a/src/toolboxes/spline/Submenu.tsx
+++ b/src/toolboxes/spline/Submenu.tsx
@@ -31,6 +31,10 @@ const Submenu = (props: Props): ReactElement => {
     );
   }
 
+  function fillSpline() {
+    document.dispatchEvent(new CustomEvent("fillSpline", { detail: "spline" }));
+  }
+
   return (
     <Popover
       open={props.isOpen}
@@ -56,6 +60,11 @@ const Submenu = (props: Props): ReactElement => {
         <BaseIconButton
           tooltip={tooltips.closespline}
           onClick={closeSpline}
+          fill={false}
+        />
+        <BaseIconButton
+          tooltip={tooltips.fillspline}
+          onClick={fillSpline}
           fill={false}
         />
       </ButtonGroup>


### PR DESCRIPTION
# Description

Users can now convert a spline to a paintbrush and fill a paintbrush strokes. Together this allows the user to use the lasso on an object and then change their mind and realise they want a painted object or just paint the edges of an object and then fill.

Note: there are some glitches to the filling algorithm. Fixing this would make a great short project for a student @BoguslawObara - the code is all open source and available for students to explore.

WILL CONVERT FROM DRAFT WHEN #271 IS MERGED AND THIS CAN BE REBASED TO MAIN.

# Dependency changes

```
    "@gliff-ai/slpf": "^1.1.0",
    "simplify-js": "^1.2.4",
```
Has the pipfile.lock or package-lock.json been updated? Yes

# Testing

None

# Documentation

@philhallbio this will need to be docoumented as part of gliff-ai/document#8

# Migrations (if applicable)

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
