### PR TITLE
feat: position BaseSlider not to hide under upload/download buttons wh…

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -943,8 +943,8 @@ class UserInterface extends Component<Props, State> {
                       className={classes.slicesSlider}
                       style={{
                         position: "absolute",
-                        top: "110px",
-                        right: "30px",
+                        top: "180px",
+                        right: "18px",
                       }}
                     >
                       <BaseSlider


### PR DESCRIPTION


## Description

Position BaseSlider so that it doesn't hide under upload/download buttons when rendered in Dominate

## Dependency changes
N/A

## Testing

N/A

## Documentation

N/A

## Migrations (if applicable)

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
