### PR TITLE
fix: make it so you can insert nodes on double click

### DIFF
--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -382,19 +382,21 @@ class CanvasClass extends Component<Props> {
   };
 
   onDoubleClick = (x: number, y: number): void => {
-    // Add new point on double-click.
-    if (this.props.mode === Mode.draw || !this.sliceIndexMatch()) return;
+    // if no spline tool is turned on then do nothing
+    if (!this.isActive()) return;
 
-    const { x: imageX, y: imageY } = canvasToImage(
-      x,
-      y,
-      this.props.displayedImage.width,
-      this.props.displayedImage.height,
-      this.props.scaleAndPan,
-      this.props.canvasPositionAndSize
-    );
-    this.addNewPointNearSpline(imageX, imageY);
-    this.drawAllSplines();
+    if (this.sliceIndexMatch()) {
+      const { x: imageX, y: imageY } = canvasToImage(
+        x,
+        y,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
+        this.props.scaleAndPan,
+        this.props.canvasPositionAndSize
+      );
+      this.addNewPointNearSpline(imageX, imageY);
+      this.drawAllSplines();
+    }
   };
 
   closeSpline = (): void => {


### PR DESCRIPTION
## Description

Because of historical reasons, we used to allow node insertion only in 'select' mode, but that makes no sense as 'draw' mode (we should probably rename this 'edit') is when you want to be able to change annotations and 'select' mode really shouldn't let you change an annotation at all.

## Documentation

@philhallbio, this doesn't seem to be a documented feature - it should become one.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
