### PR TITLE
feat: refactor background toolbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gliff-ai/annotate",
-  "version": "0.23.0",
+  "version": "0.26.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gliff-ai/annotate",
-      "version": "0.23.0",
+      "version": "0.26.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@gliff-ai/slpf": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gliff-ai/annotate",
-  "version": "0.23.0",
+  "version": "0.26.0",
   "description": "gliff.ai ANNOTATE - a user friendly browser interface for annotating multidimensional images for machine learning",
   "repository": "git://github.com/gliff-ai/annotate.git",
   "main": "dist/index.es.js",

--- a/src/Toolboxes.ts
+++ b/src/Toolboxes.ts
@@ -1,6 +1,7 @@
 import { Tooltip } from "@gliff-ai/style";
 
 export const Toolboxes = {
+  background: "background",
   paintbrush: "paintbrush",
   spline: "spline",
   boundingBox: "boundingBox",

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -194,7 +194,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
   );
 };
 
-const events = ["selectSettings"] as const;
+const events = ["selectBackgroundSettings"] as const;
 
 interface Event extends CustomEvent {
   type: typeof events[number];

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -1,38 +1,51 @@
 import {
+  Component,
   ChangeEvent,
   ReactElement,
-  useEffect,
   useState,
   MouseEvent,
 } from "react";
-
 import {
-  Typography,
+  ButtonGroup,
   Checkbox,
   FormControlLabel,
   FormGroup,
   FormControl,
   Popover,
   Card,
-  Paper,
-  Avatar,
   makeStyles,
   createStyles,
   Theme,
+  CardHeader,
+  CardContent,
 } from "@material-ui/core";
 import SVG from "react-inlinesvg";
 
+import { BaseIconButton } from "@gliff-ai/style";
 import { BaseSlider } from "@/components/BaseSlider";
-import { Sliders, SLIDER_CONFIG } from "./configSlider";
-
-import { useBackgroundStore } from "./Store";
-
+import { Toolboxes } from "@/Toolboxes";
 import { imgSrc } from "@/imgSrc";
 
-interface Props {
-  anchorElement: HTMLElement | null;
-  buttonClicked: string;
+import { Tools } from "./Toolbox";
+import { useBackgroundStore } from "./Store";
+import { Sliders, SLIDER_CONFIG } from "./configSlider";
+
+interface SubmenuProps {
+  isOpen: boolean;
+  anchorElement: HTMLButtonElement | null;
   onClose: (event: MouseEvent) => void;
+  channelControls: ReactElement[];
+}
+
+interface Props {
+  buttonClicked: string;
+  setButtonClicked: (buttonName: string) => void;
+  handleOpen: (
+    event?: MouseEvent
+  ) => (anchorElement?: HTMLButtonElement) => void;
+  onClose: (event: MouseEvent) => void;
+  anchorElement: HTMLButtonElement | null;
+  isTyping: () => boolean;
   channels: boolean[];
   toggleChannelAtIndex: (index: number) => void;
   displayedImage: ImageBitmap;
@@ -40,55 +53,40 @@ interface Props {
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    checkbox: {
-      marginLeft: "104px",
+    subMenu: {
+      display: "flex",
+      justifyContent: "space-between",
+      //   width: "136px",
+      height: "285px",
+      background: "none",
     },
-    contrastSlider: {
+    subMenuCard: {
+      height: "285px",
+      marginLeft: "18px", // TODO other toolbars should use this approach
+    },
+    baseSlider: {
       width: "63px",
-      height: "335px",
+      height: "250px",
+      textAlign: "center",
     },
-    brightnessSlider: {
-      width: "63px",
-      height: "335px",
-    },
-    channelCard: {
-      width: "189px",
-      height: "176px",
+    channelHeader: {
+      backgroundColor: theme.palette.primary.main,
     },
     channelTypography: {
       display: "inline",
       fontSize: "21px",
-      marginRight: "54px",
-      marginLeft: "3px",
-    },
-    channelAvatar: {
-      backgroundColor: theme.palette.primary.main,
-      display: "inline",
-    },
-    channelformGroup: {
-      margin: "0",
-      padding: "0",
-      marginLeft: "17px",
-    },
-    channelPaper: {
-      padding: "10px",
-      backgroundColor: theme.palette.primary.main,
-      width: "189px",
-      marginBottom: "15px",
+      marginRight: "18px",
     },
   })
 );
 
-const Toolbar = (props: Props): ReactElement => {
+const Submenu = (props: SubmenuProps): ReactElement => {
   const [background, setBackground] = useBackgroundStore();
-  const [channelControls, setChannelControls] = useState<JSX.Element[]>([]);
+  const [buttonClicked, setButtonClicked] = useState(null as string);
   const classes = useStyles();
 
-  function changeContrast(e: ChangeEvent, value: number) {
-    setBackground({
-      contrast: value,
-      brightness: background.brightness,
-    });
+  function selectBrightness() {
+    setButtonClicked(Tools.brightness.name);
   }
 
   function changeBrightness(e: ChangeEvent, value: number) {
@@ -98,13 +96,144 @@ const Toolbar = (props: Props): ReactElement => {
     });
   }
 
-  const isOpen = () =>
-    (props.buttonClicked === "Channels" ||
-      props.buttonClicked === "Brightness" ||
-      props.buttonClicked === "Contrast") &&
-    Boolean(props.anchorElement);
+  function selectContrast() {
+    setButtonClicked(Tools.contrast.name);
+  }
 
-  useEffect(() => {
+  function changeContrast(e: ChangeEvent, value: number) {
+    setBackground({
+      contrast: value,
+      brightness: background.brightness,
+    });
+  }
+
+  function selectChannels() {
+    setButtonClicked(Tools.channels.name);
+  }
+
+  return (
+    <>
+      <Popover
+        open={props.isOpen}
+        anchorEl={props.anchorElement}
+        onClose={props.onClose}
+        PaperProps={{ classes: { root: classes.subMenu } }}
+      >
+        <ButtonGroup
+          orientation="vertical"
+          size="small"
+          id="background-settings-toolbar"
+        >
+          <BaseIconButton
+            tooltip={Tools.brightness}
+            onClick={() => selectBrightness()}
+            fill={buttonClicked === Tools.brightness.name}
+          />
+          <BaseIconButton
+            tooltip={Tools.contrast}
+            onClick={() => selectContrast()}
+            fill={buttonClicked === Tools.contrast.name}
+          />
+          <BaseIconButton
+            tooltip={Tools.channels}
+            onClick={() => selectChannels()}
+            fill={buttonClicked === Tools.channels.name}
+          />
+        </ButtonGroup>
+        <Card className={classes.subMenuCard}>
+          {buttonClicked === Tools.brightness.name && (
+            <div className={classes.baseSlider}>
+              <BaseSlider
+                value={background.brightness}
+                config={SLIDER_CONFIG[Sliders.brightness]}
+                onChange={() => changeBrightness}
+                showEndValues={false}
+              />
+            </div>
+          )}
+          {buttonClicked === Tools.contrast.name && (
+            <div className={classes.baseSlider}>
+              <BaseSlider
+                value={background.contrast}
+                config={SLIDER_CONFIG[Sliders.contrast]}
+                onChange={() => changeContrast}
+                showEndValues={false}
+              />
+            </div>
+          )}
+          {buttonClicked === Tools.channels.name && props.channelControls && (
+            <>
+              <CardHeader
+                className={classes.channelHeader}
+                title="Channels"
+                titleTypographyProps={{ className: classes.channelTypography }}
+                action={
+                  <SVG src={imgSrc("pin-icon")} width="18px" height="auto" />
+                }
+              />
+              <CardContent>
+                <FormControl component="fieldset">
+                  <FormGroup aria-label="position" row>
+                    {props.channelControls.map((control, i) => (
+                      <FormControlLabel
+                        key={`C${i + 1}`}
+                        value="top"
+                        control={control}
+                        label={`C${i + 1}`}
+                        labelPlacement="start"
+                      />
+                    ))}
+                  </FormGroup>
+                </FormControl>
+              </CardContent>
+            </>
+          )}
+        </Card>
+      </Popover>
+    </>
+  );
+};
+
+const events = ["selectSettings"] as const;
+
+interface Event extends CustomEvent {
+  type: typeof events[number];
+}
+class Toolbar extends Component<Props> {
+  private refBackgroundSettingsPopover: HTMLButtonElement;
+
+  private channelControls: JSX.Element[];
+
+  constructor(props: Props) {
+    super(props);
+    this.channelControls = null;
+    this.refBackgroundSettingsPopover = null;
+  }
+
+  componentDidMount = (): void => {
+    for (const event of events) {
+      document.addEventListener(event, this.handleEvent);
+    }
+    this.updateChannelChoices();
+  };
+
+  componentDidUpdate = (): void => {
+    this.updateChannelChoices();
+  };
+
+  componentWillUnmount(): void {
+    for (const event of events) {
+      document.removeEventListener(event, this.handleEvent);
+    }
+  }
+
+  handleEvent = (event: Event): void => {
+    if (event.detail === Toolboxes.background) {
+      this[event.type]?.call(this);
+    }
+  };
+
+  updateChannelChoices = (): void => {
     // Update channel controls when a new image is uploaded.
     const untickedIcon = (
       <SVG
@@ -116,82 +245,46 @@ const Toolbar = (props: Props): ReactElement => {
     const tickedIcon = (
       <SVG src={imgSrc("selected-tickbox-icon")} width="18px" height="auto" />
     );
-    setChannelControls(
-      props.channels.map((channel, i) => (
-        <Checkbox
-          className={classes.checkbox}
-          checked={channel}
-          icon={untickedIcon}
-          checkedIcon={tickedIcon}
-          onChange={() => {
-            props.toggleChannelAtIndex(i);
-          }}
-        />
-      ))
-    );
-  }, [props.displayedImage]);
+    this.channelControls = this.props.channels.map((channel, i) => (
+      <Checkbox
+        // className={classes.checkbox}
+        checked={channel}
+        icon={untickedIcon}
+        checkedIcon={tickedIcon}
+        onChange={() => {
+          this.props.toggleChannelAtIndex(i);
+        }}
+      />
+    ));
+  };
 
-  return props.displayedImage ? (
+  selectBackgroundSettings = (): void => {
+    if (this.props.isTyping()) return;
+    this.props.handleOpen()(this.refBackgroundSettingsPopover);
+    this.props.setButtonClicked(Tools.brightness.name);
+  };
+
+  render = (): ReactElement => (
     <>
-      <Popover
-        open={isOpen()}
-        anchorEl={props.anchorElement}
-        onClose={props.onClose}
-      >
-        {props.buttonClicked === "Contrast" && (
-          <div className={classes.contrastSlider}>
-            <BaseSlider
-              value={background.contrast}
-              config={SLIDER_CONFIG[Sliders.contrast]}
-              onChange={() => changeContrast}
-            />
-          </div>
-        )}
-
-        {props.buttonClicked === "Brightness" && (
-          <div className={classes.brightnessSlider}>
-            <BaseSlider
-              value={background.brightness}
-              config={SLIDER_CONFIG[Sliders.brightness]}
-              onChange={() => changeBrightness}
-            />
-          </div>
-        )}
-
-        {props.buttonClicked === "Channels" && (
-          <Card className={classes.channelCard}>
-            <Paper
-              elevation={0}
-              variant="outlined"
-              square
-              className={classes.channelPaper}
-            >
-              <Typography className={classes.channelTypography}>
-                Channels
-              </Typography>
-              <Avatar className={classes.channelAvatar}>
-                <SVG src={imgSrc("pin-icon")} width="18px" height="auto" />
-              </Avatar>
-            </Paper>
-            <FormControl component="fieldset">
-              <FormGroup aria-label="position" row>
-                {channelControls.map((control, i) => (
-                  <FormControlLabel
-                    key={`C${i + 1}`}
-                    value="top"
-                    control={control}
-                    label={`C${i + 1}`}
-                    labelPlacement="start"
-                    className={classes.channelformGroup}
-                  />
-                ))}
-              </FormGroup>
-            </FormControl>
-          </Card>
-        )}
-      </Popover>
+      <BaseIconButton
+        tooltip={Tools.brightness}
+        onClick={this.selectBackgroundSettings}
+        fill={this.props.buttonClicked === Tools.brightness.name}
+        setRefCallback={(ref) => {
+          this.refBackgroundSettingsPopover = ref;
+        }}
+      />
+      <Submenu
+        isOpen={
+          this.props.buttonClicked === Tools.brightness.name &&
+          Boolean(this.props.anchorElement)
+        }
+        anchorElement={this.props.anchorElement}
+        onClose={this.props.onClose}
+        channelControls={this.channelControls}
+      />
     </>
-  ) : null;
-};
+  );
+}
 
 export { Toolbar };

--- a/src/toolboxes/background/Toolbox.ts
+++ b/src/toolboxes/background/Toolbox.ts
@@ -1,0 +1,24 @@
+import { imgSrc } from "@/imgSrc";
+import { ToolTips } from "@/Toolboxes";
+
+const ToolboxName: Toolbox = "background";
+
+const Tools: ToolTips = {
+  contrast: {
+    name: "Contrast",
+    icon: imgSrc("contrast-icon"),
+    shortcut: `\\`,
+  },
+  brightness: {
+    name: "Brightness",
+    icon: imgSrc("brightness-icon"),
+    shortcut: "/",
+  },
+  channels: {
+    name: "Channels",
+    icon: imgSrc("channels-icon"),
+    shortcut: "C",
+  },
+} as const;
+
+export { ToolboxName, Tools };

--- a/src/toolboxes/background/Toolbox.ts
+++ b/src/toolboxes/background/Toolbox.ts
@@ -1,5 +1,5 @@
 import { imgSrc } from "@/imgSrc";
-import { ToolTips } from "@/Toolboxes";
+import { Toolbox, ToolTips } from "@/Toolboxes";
 
 const ToolboxName: Toolbox = "background";
 

--- a/src/toolboxes/background/ToolboxMinimap.ts
+++ b/src/toolboxes/background/ToolboxMinimap.ts
@@ -1,0 +1,37 @@
+import { imgSrc } from "@/imgSrc";
+import { ToolTips } from "@/Toolboxes";
+
+const Tools: ToolTips = {
+  minimiseMap: {
+    name: "Minimise Map",
+    icon: imgSrc("minimise-icon"),
+    shortcut: "ALT",
+    shortcutSymbol: "-",
+  },
+  maximiseMap: {
+    name: "Maximise Map",
+    icon: imgSrc("maximise-icon"),
+    shortcut: "ALT",
+    shortcutSymbol: "=",
+  },
+  zoomIn: {
+    name: "Zoom In",
+    icon: imgSrc("zoom-in-icon"),
+    shortcut: "ALT",
+    shortcutSymbol: "1",
+  },
+  zoomOut: {
+    name: "Zoom Out",
+    icon: imgSrc("zoom-out-icon"),
+    shortcut: "ALT",
+    shortcutSymbol: "2",
+  },
+  fitToPage: {
+    name: "Fit to Page",
+    icon: imgSrc("reset-zoom-and-pan-icon"),
+    shortcut: "ALT",
+    shortcutSymbol: "3",
+  },
+} as const;
+
+export { Tools as MinimapTools };

--- a/src/toolboxes/background/index.ts
+++ b/src/toolboxes/background/index.ts
@@ -1,3 +1,5 @@
+export { Tools as BackgroundTools } from "./Toolbox";
+export { MinimapTools } from "./ToolboxMinimap";
 export { Canvas as BackgroundCanvas } from "./Canvas";
 export { Toolbar as BackgroundToolbar } from "./Toolbar";
 export { Minimap } from "./Minimap";

--- a/src/toolboxes/boundingBox/index.ts
+++ b/src/toolboxes/boundingBox/index.ts
@@ -1,6 +1,6 @@
 export {
   ToolboxName as BoundingBoxToolboxName,
-  Tools as BoundingBoxToolbox,
+  Tools as BoundingBoxTools,
 } from "./Toolbox";
 export { Canvas as BoundingBoxCanvas, events } from "./Canvas";
 export { Toolbar as BoundingBoxToolbar } from "./Toolbar";

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -6,17 +6,32 @@ import {
   Paper,
   Popover,
 } from "@material-ui/core";
+
 import { BaseIconButton } from "@gliff-ai/style";
+
 import { Toolbox, Toolboxes } from "@/Toolboxes";
 import { BaseSlider } from "@/components/BaseSlider";
-import { Sliders, SLIDER_CONFIG } from "./configSlider";
-import { usePaintbrushStore } from "./Store";
-import { ToolboxName, Tools } from "./Toolbox";
 
-interface SubMenuProps {
+import { ToolboxName, Tools } from "./Toolbox";
+import { usePaintbrushStore } from "./Store";
+import { Sliders, SLIDER_CONFIG } from "./configSlider";
+
+interface SubmenuProps {
   isOpen: boolean;
   anchorElement: HTMLButtonElement | null;
   onClose: (event: MouseEvent) => void;
+}
+
+interface Props {
+  buttonClicked: string;
+  setButtonClicked: (buttonName: string) => void;
+  activateToolbox: (activeToolbox: Toolbox) => void;
+  handleOpen: (
+    event?: MouseEvent
+  ) => (anchorElement?: HTMLButtonElement) => void;
+  onClose: (event: MouseEvent) => void;
+  anchorElement: HTMLButtonElement | null;
+  isTyping: () => boolean;
 }
 
 const useStyles = makeStyles(() =>
@@ -35,7 +50,7 @@ const useStyles = makeStyles(() =>
   })
 );
 
-const Submenu = (props: SubMenuProps): ReactElement => {
+const Submenu = (props: SubmenuProps): ReactElement => {
   const [paintbrush, setPaintbrush] = usePaintbrushStore();
   const classes = useStyles();
 
@@ -81,17 +96,17 @@ const Submenu = (props: SubMenuProps): ReactElement => {
         >
           <BaseIconButton
             tooltip={Tools.paintbrush}
-            onClick={() => selectBrush}
+            onClick={() => selectBrush()}
             fill={paintbrush.brushType === Tools.paintbrush.name}
           />
           <BaseIconButton
             tooltip={Tools.eraser}
-            onClick={() => selectEraser}
+            onClick={() => selectEraser()}
             fill={paintbrush.brushType === Tools.eraser.name}
           />
           <BaseIconButton
             tooltip={Tools.fillbrush}
-            onClick={() => fillBrush}
+            onClick={() => fillBrush()}
             fill={false}
           />
         </ButtonGroup>
@@ -109,18 +124,6 @@ const Submenu = (props: SubMenuProps): ReactElement => {
     </>
   );
 };
-
-interface Props {
-  buttonClicked: string;
-  setButtonClicked: (buttonName: string) => void;
-  activateToolbox: (activeToolbox: Toolbox) => void;
-  handleOpen: (
-    event?: MouseEvent
-  ) => (anchorElement?: HTMLButtonElement) => void;
-  onClose: (event: MouseEvent) => void;
-  anchorElement: HTMLButtonElement | null;
-  isTyping: () => boolean;
-}
 
 const events = ["selectBrush"] as const;
 

--- a/src/toolboxes/paintbrush/index.ts
+++ b/src/toolboxes/paintbrush/index.ts
@@ -1,6 +1,6 @@
 export {
   ToolboxName as PaintbrushToolboxName,
-  Tools as PaintbrushToolbox,
+  Tools as PaintbrushTools,
 } from "./Toolbox";
 export { Canvas as PaintbrushCanvas } from "./Canvas";
 export { Toolbar as PaintbrushToolbar } from "./Toolbar";

--- a/src/toolboxes/spline/Toolbar.tsx
+++ b/src/toolboxes/spline/Toolbar.tsx
@@ -7,13 +7,13 @@ import { useSplineStore } from "./Store";
 
 const events = ["selectSpline"] as const;
 
-interface SubMenuProps {
+interface SubmenuProps {
   isOpen: boolean;
   anchorElement: HTMLButtonElement | null;
   onClose: (event: MouseEvent) => void;
 }
 
-const Submenu = (props: SubMenuProps): ReactElement => {
+const Submenu = (props: SubmenuProps): ReactElement => {
   const [spline, setSpline] = useSplineStore();
 
   function selectSpline() {

--- a/src/toolboxes/spline/index.ts
+++ b/src/toolboxes/spline/index.ts
@@ -1,6 +1,6 @@
 export {
   ToolboxName as SplineToolboxName,
-  Tools as SplineToolbox,
+  Tools as SplineTools,
 } from "./Toolbox";
 export { Canvas as SplineCanvas, events } from "./Canvas";
 export { Toolbar as SplineToolbar } from "./Toolbar";

--- a/src/tooltips/index.ts
+++ b/src/tooltips/index.ts
@@ -1,44 +1,14 @@
-import type { Tooltip } from "@gliff-ai/style";
-
-import { PaintbrushToolbox } from "@/toolboxes/paintbrush";
-import { SplineToolbox } from "@/toolboxes/spline";
-import { BoundingBoxToolbox } from "@/toolboxes/boundingBox";
+import { Tooltip } from "@gliff-ai/style";
+import { BackgroundTools, MinimapTools } from "@/toolboxes/background";
+import { PaintbrushTools } from "@/toolboxes/paintbrush";
+import { SplineTools } from "@/toolboxes/spline";
+import { BoundingBoxTools } from "@/toolboxes/boundingBox";
 
 import { imgSrc } from "@/imgSrc";
 
 type ToolTips = { [name: string]: Tooltip };
 
 const DefaultTools: ToolTips = {
-  minimiseMap: {
-    name: "Minimise Map",
-    icon: imgSrc("minimise-icon"),
-    shortcut: "ALT",
-    shortcutSymbol: "-",
-  },
-  maximiseMap: {
-    name: "Maximise Map",
-    icon: imgSrc("maximise-icon"),
-    shortcut: "ALT",
-    shortcutSymbol: "=",
-  },
-  zoomIn: {
-    name: "Zoom In",
-    icon: imgSrc("zoom-in-icon"),
-    shortcut: "ALT",
-    shortcutSymbol: "1",
-  },
-  zoomOut: {
-    name: "Zoom Out",
-    icon: imgSrc("zoom-out-icon"),
-    shortcut: "ALT",
-    shortcutSymbol: "2",
-  },
-  fitToPage: {
-    name: "Fit to Page",
-    icon: imgSrc("reset-zoom-and-pan-icon"),
-    shortcut: "ALT",
-    shortcutSymbol: "3",
-  },
   addNewAnnotation: {
     name: "Add New Annotation",
     icon: imgSrc("new-annotation-icon"),
@@ -53,21 +23,6 @@ const DefaultTools: ToolTips = {
     name: "Select",
     icon: imgSrc("select-icon"),
     shortcut: "A",
-  },
-  contrast: {
-    name: "Contrast",
-    icon: imgSrc("contrast-icon"),
-    shortcut: `\\`,
-  },
-  brightness: {
-    name: "Brightness",
-    icon: imgSrc("brightness-icon"),
-    shortcut: "/",
-  },
-  channels: {
-    name: "Channels",
-    icon: imgSrc("channels-icon"),
-    shortcut: "C",
   },
   labels: {
     name: "Annotation Label",
@@ -107,9 +62,11 @@ const DefaultTools: ToolTips = {
 
 const Tools: ToolTips = {
   ...DefaultTools,
-  ...PaintbrushToolbox,
-  ...BoundingBoxToolbox,
-  ...SplineToolbox,
+  ...BackgroundTools,
+  ...MinimapTools,
+  ...PaintbrushTools,
+  ...BoundingBoxTools,
+  ...SplineTools,
 };
 
 export { Tools };

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -103,6 +103,17 @@ const styles = {
   displayContainer: {
     marginTop: "18px",
   },
+  leftToolbar: {
+    display: "flex",
+    flexDirection: "column",
+    top: "108px",
+    left: "18px",
+    bottom: "18px",
+    width: "63px",
+    zIndex: 100,
+    justifyContent: "space-between",
+    position: "fixed",
+  },
   bottomToolbars: {
     bottom: "18px",
     left: "18px",
@@ -708,169 +719,123 @@ class UserInterface extends Component<Props, State> {
       </AppBar>
     );
 
+    const leftToolbar = (
+      <Toolbar className={classes.leftToolbar}>
+        <ButtonGroup size="small">
+          <BaseIconButton
+            tooltip={Tools.select}
+            onClick={this.toggleMode}
+            fill={this.state.buttonClicked === Tools.select.name}
+          />
+          <BaseIconButton
+            tooltip={Tools.addNewAnnotation}
+            onMouseDown={() => {
+              this.setButtonClicked(Tools.addNewAnnotation.name);
+              this.addAnnotation();
+            }}
+            onMouseUp={this.selectDrawMode}
+            fill={this.state.buttonClicked === Tools.addNewAnnotation.name}
+          />
+          <BaseIconButton
+            tooltip={Tools.clearAnnotation}
+            onMouseDown={() => {
+              this.setButtonClicked(Tools.clearAnnotation.name);
+              this.clearActiveAnnotation();
+            }}
+            onMouseUp={this.selectDrawMode}
+            fill={this.state.buttonClicked === Tools.clearAnnotation.name}
+          />
+          {saveAnnotationsCallback && (
+            <BaseIconButton
+              tooltip={Tools.save}
+              onMouseDown={() => {
+                this.setButtonClicked(Tools.save.name);
+                this.saveAnnotations();
+              }}
+              onMouseUp={this.selectDrawMode}
+              fill={this.state.buttonClicked === Tools.save.name}
+            />
+          )}
+          <BaseIconButton
+            tooltip={Tools.labels}
+            onClick={this.selectAnnotationLabel}
+            fill={this.state.buttonClicked === Tools.labels.name}
+            setRefCallback={(ref) => {
+              this.refBtnsPopovers[Tools.labels.name] = ref;
+            }}
+          />
+          <BaseIconButton
+            tooltip={Tools.undo}
+            onClick={this.undo}
+            fill={false}
+            enabled={this.state.canUndoRedo.undo}
+          />
+          <BaseIconButton
+            tooltip={Tools.redo}
+            onClick={this.redo}
+            fill={false}
+            enabled={this.state.canUndoRedo.redo}
+          />
+        </ButtonGroup>
+
+        <ButtonGroup>
+          <PaintbrushToolbar
+            buttonClicked={this.state.buttonClicked}
+            setButtonClicked={this.setButtonClicked}
+            activateToolbox={this.activateToolbox}
+            handleOpen={this.handleOpen}
+            onClose={this.handleClose}
+            anchorElement={this.state.anchorElement}
+            isTyping={this.isTyping}
+          />
+          <SplineToolbar
+            buttonClicked={this.state.buttonClicked}
+            setButtonClicked={this.setButtonClicked}
+            activateToolbox={this.activateToolbox}
+            handleOpen={this.handleOpen}
+            onClose={this.handleClose}
+            anchorElement={this.state.anchorElement}
+            isTyping={this.isTyping}
+          />
+          <BoundingBoxToolbar
+            buttonClicked={this.state.buttonClicked}
+            setButtonClicked={this.setButtonClicked}
+            activateToolbox={this.activateToolbox}
+            isTyping={this.isTyping}
+          />
+          <BackgroundToolbar
+            buttonClicked={this.state.buttonClicked}
+            setButtonClicked={this.setButtonClicked}
+            handleOpen={this.handleOpen}
+            onClose={this.handleClose}
+            anchorElement={this.state.anchorElement}
+            isTyping={this.isTyping}
+            channels={this.state.channels}
+            toggleChannelAtIndex={this.toggleChannelAtIndex}
+            displayedImage={this.state.displayedImage}
+          />
+        </ButtonGroup>
+
+        <LabelsSubmenu
+          isOpen={
+            this.state.buttonClicked === "Annotation Label" &&
+            Boolean(this.state.anchorElement)
+          }
+          anchorElement={this.state.anchorElement}
+          onClose={this.handleClose}
+          annotationsObject={this.annotationsObject}
+          presetLabels={this.presetLabels}
+          updatePresetLabels={this.updatePresetLabels}
+          activeAnnotationID={this.state.activeAnnotationID}
+        />
+      </Toolbar>
+    );
+
     return (
       <StylesProvider generateClassName={generateClassName("annotate")}>
         <ThemeProvider theme={theme}>
           <Grid container className={classes.mainContainer}>
-            <Grid
-              container
-              direction="row"
-              className={classes.selectionContainer}
-              style={{ position: "fixed" }}
-            >
-              <ButtonGroup size="small" id="selection-toolbar">
-                <BaseIconButton
-                  tooltip={Tools.select}
-                  onClick={this.toggleMode}
-                  fill={this.state.buttonClicked === Tools.select.name}
-                />
-                <BaseIconButton
-                  tooltip={Tools.addNewAnnotation}
-                  onMouseDown={() => {
-                    this.setButtonClicked(Tools.addNewAnnotation.name);
-                    this.addAnnotation();
-                  }}
-                  onMouseUp={this.selectDrawMode}
-                  fill={
-                    this.state.buttonClicked === Tools.addNewAnnotation.name
-                  }
-                />
-                <BaseIconButton
-                  tooltip={Tools.clearAnnotation}
-                  onMouseDown={() => {
-                    this.setButtonClicked(Tools.clearAnnotation.name);
-                    this.clearActiveAnnotation();
-                  }}
-                  onMouseUp={this.selectDrawMode}
-                  fill={this.state.buttonClicked === Tools.clearAnnotation.name}
-                />
-                {saveAnnotationsCallback && (
-                  <BaseIconButton
-                    tooltip={Tools.save}
-                    onMouseDown={() => {
-                      this.setButtonClicked(Tools.save.name);
-                      this.saveAnnotations();
-                    }}
-                    onMouseUp={this.selectDrawMode}
-                    fill={this.state.buttonClicked === Tools.save.name}
-                  />
-                )}
-                <BaseIconButton
-                  tooltip={Tools.labels}
-                  onClick={this.selectAnnotationLabel}
-                  fill={this.state.buttonClicked === Tools.labels.name}
-                  setRefCallback={(ref) => {
-                    this.refBtnsPopovers[Tools.labels.name] = ref;
-                  }}
-                />
-                <BaseIconButton
-                  tooltip={Tools.undo}
-                  onClick={this.undo}
-                  fill={false}
-                  enabled={this.state.canUndoRedo.undo}
-                />
-                <BaseIconButton
-                  tooltip={Tools.redo}
-                  onClick={this.redo}
-                  fill={false}
-                  enabled={this.state.canUndoRedo.redo}
-                />
-              </ButtonGroup>
-            </Grid>
-
-            <Grid
-              container
-              direction="row"
-              className={classes.bottomToolbars}
-              style={{ position: "fixed" }}
-            >
-              <Grid container direction="row">
-                <ButtonGroup id="paint-toolbar">
-                  <PaintbrushToolbar
-                    buttonClicked={this.state.buttonClicked}
-                    setButtonClicked={this.setButtonClicked}
-                    activateToolbox={this.activateToolbox}
-                    handleOpen={this.handleOpen}
-                    onClose={this.handleClose}
-                    anchorElement={this.state.anchorElement}
-                    isTyping={this.isTyping}
-                  />
-                  <SplineToolbar
-                    buttonClicked={this.state.buttonClicked}
-                    setButtonClicked={this.setButtonClicked}
-                    activateToolbox={this.activateToolbox}
-                    handleOpen={this.handleOpen}
-                    onClose={this.handleClose}
-                    anchorElement={this.state.anchorElement}
-                    isTyping={this.isTyping}
-                  />
-                  <BoundingBoxToolbar
-                    buttonClicked={this.state.buttonClicked}
-                    setButtonClicked={this.setButtonClicked}
-                    activateToolbox={this.activateToolbox}
-                    isTyping={this.isTyping}
-                  />
-                  {this.props.trustedServiceButtonToolbar}
-                </ButtonGroup>
-              </Grid>
-
-              <Grid
-                container
-                direction="row"
-                className={classes.displayContainer}
-              >
-                <ButtonGroup id="display-toolbar">
-                  <BaseIconButton
-                    tooltip={Tools.brightness}
-                    onClick={this.selectBrightness}
-                    fill={this.state.buttonClicked === Tools.brightness.name}
-                    setRefCallback={(ref) => {
-                      this.refBtnsPopovers[Tools.brightness.name] = ref;
-                    }}
-                  />
-                  <BaseIconButton
-                    tooltip={Tools.contrast}
-                    onClick={this.selectContrast}
-                    fill={this.state.buttonClicked === Tools.contrast.name}
-                    setRefCallback={(ref) => {
-                      this.refBtnsPopovers[Tools.contrast.name] = ref;
-                    }}
-                  />
-                  <BaseIconButton
-                    tooltip={Tools.channels}
-                    onClick={this.selectChannels}
-                    fill={this.state.buttonClicked === Tools.channels.name}
-                    setRefCallback={(ref) => {
-                      this.refBtnsPopovers[Tools.channels.name] = ref;
-                    }}
-                  />
-                </ButtonGroup>
-              </Grid>
-            </Grid>
-
-            <LabelsSubmenu
-              isOpen={
-                this.state.buttonClicked === "Annotation Label" &&
-                Boolean(this.state.anchorElement)
-              }
-              anchorElement={this.state.anchorElement}
-              onClose={this.handleClose}
-              annotationsObject={this.annotationsObject}
-              presetLabels={this.presetLabels}
-              updatePresetLabels={this.updatePresetLabels}
-              activeAnnotationID={this.state.activeAnnotationID}
-            />
-            <BackgroundToolbar
-              buttonClicked={this.state.buttonClicked}
-              anchorElement={this.state.anchorElement}
-              onClose={this.handleClose}
-              channels={this.state.channels}
-              toggleChannelAtIndex={this.toggleChannelAtIndex}
-              displayedImage={this.state.displayedImage}
-            />
-
             <CssBaseline />
-
             <Container
               disableGutters
               maxWidth={false}
@@ -879,6 +844,7 @@ class UserInterface extends Component<Props, State> {
               }}
             >
               {appBar}
+              {leftToolbar}
               <Grid
                 container
                 spacing={0}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -105,14 +105,14 @@ const styles = {
   },
   leftToolbar: {
     display: "flex",
-    flexDirection: "column",
+    flexDirection: "column" as const,
     top: "108px",
     left: "18px",
     bottom: "18px",
     width: "63px",
     zIndex: 100,
     justifyContent: "space-between",
-    position: "fixed",
+    position: "fixed" as const,
   },
   bottomToolbars: {
     bottom: "18px",


### PR DESCRIPTION
## Description

~~*HELP WANTED* There are two lint errors on line 237 of `src/toolboxes/background/Toolbar.tsx`. However this was copy and pasted from `src/toolboxes/paintbrush/Toolbar.tsx` where it doesn't cause an error. Any ideas?~~

Refactors the background toolbox to match the other as done in #317.

As part of this puts background settings buttons into a submenu-style toolbar. @joshuajames-smith this will need an icon, maybe something like the material 'photo' icons.

~~Currently merging into #328, will rebase when that is merged.~~

## Dependency changes

No dependency changes.

Has the pipfile.lock or package-lock.json been updated? Yes for version bump.

## Documentation

@philhallbio this will need to be updated in the documentation once @joshuajames-smith has helped out with icons.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] If appropriate, I have bumped any version numbers
