### PR TITLE
feat: add ability to control annotation transparency for paintbrush toolbox

### DIFF
--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -524,7 +524,10 @@ export class CanvasClass extends Component<Props, State> {
 }
 
 export const Canvas = (
-  props: Omit<Props, "brushRadius" | "isActive">
+  props: Omit<
+    Props,
+    "brushRadius" | "isActive" | "annotationAlpha" | "annotationActiveAlpha"
+  >
 ): ReactElement => {
   // we will overwrite props.activeToolbox, which will be paintbrush
   // with paintbrush.brushType, which will be paintbrush/eraser

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -33,6 +33,8 @@ interface Props extends CanvasProps {
   mode: Mode;
   annotationsObject: Annotations;
   brushRadius: number;
+  annotationActiveAlpha: number;
+  annotationAlpha: number;
   redraw: number;
   sliceIndex: number;
   setUIActiveAnnotationID: (id: number) => void;
@@ -119,7 +121,7 @@ export class CanvasClass extends Component<Props, State> {
     this.isPressing = false;
     this.isDrawing = false;
     this.points = [];
-    this.annotationOpacity = 1;
+    this.annotationOpacity = this.props.annotationActiveAlpha;
     this.backgroundCanvas = null;
 
     this.state = {
@@ -209,10 +211,10 @@ export class CanvasClass extends Component<Props, State> {
     // Set annotation colour and transparency
     if (isActive) {
       context.strokeStyle = mainColor;
-      this.annotationOpacity = 1;
+      this.annotationOpacity = this.props.annotationActiveAlpha;
     } else {
       context.strokeStyle = brush.color;
-      this.annotationOpacity = 0.5;
+      this.annotationOpacity = this.props.annotationAlpha;
     }
     context.globalAlpha = this.annotationOpacity;
 
@@ -545,6 +547,8 @@ export const Canvas = (
       scaleAndPan={props.scaleAndPan}
       canvasPositionAndSize={props.canvasPositionAndSize}
       brushRadius={paintbrush.brushRadius}
+      annotationActiveAlpha={paintbrush.annotationActiveAlpha / 100}
+      annotationAlpha={paintbrush.annotationAlpha / 100}
       redraw={props.redraw}
       sliceIndex={props.sliceIndex}
       setUIActiveAnnotationID={props.setUIActiveAnnotationID}

--- a/src/toolboxes/paintbrush/Store.ts
+++ b/src/toolboxes/paintbrush/Store.ts
@@ -1,15 +1,20 @@
 import { createStore } from "@/store";
 import { Tools } from "./Toolbox";
+import { SLIDER_CONFIG, Sliders } from "./configSlider";
 
 // types will include: paintbrush, eraser
 interface PaintbrushData {
   brushType: string;
   brushRadius: number;
+  annotationAlpha: number;
+  annotationActiveAlpha: number;
 }
 
 const defaultPaintbrush: PaintbrushData = {
   brushType: Tools.paintbrush.name,
-  brushRadius: 10,
+  brushRadius: SLIDER_CONFIG[Sliders.brushRadius].initial,
+  annotationAlpha: SLIDER_CONFIG[Sliders.annotationAlpha].initial,
+  annotationActiveAlpha: SLIDER_CONFIG[Sliders.annotationActiveAlpha].initial,
 };
 
 // we've created store with initial value. This can now be used anywhere and will share the value.

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -10,7 +10,6 @@ import {
   Card,
   createStyles,
   makeStyles,
-  Paper,
   Popover,
 } from "@material-ui/core";
 

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -1,6 +1,13 @@
-import { Component, ChangeEvent, ReactElement, MouseEvent } from "react";
+import {
+  Component,
+  ChangeEvent,
+  ReactElement,
+  MouseEvent,
+  useState,
+} from "react";
 import {
   ButtonGroup,
+  Card,
   createStyles,
   makeStyles,
   Paper,
@@ -44,20 +51,30 @@ const useStyles = makeStyles(() =>
     subMenu: {
       display: "flex",
       justifyContent: "space-between",
-      width: "136px",
       background: "none",
+    },
+    subMenuCard: {
+      height: "285px",
+      marginLeft: "18px", // TODO other toolbars should use this approach
+    },
+    baseSliderContainer: {
+      display: "flex",
+      flexDirection: "row",
     },
   })
 );
 
 const Submenu = (props: SubmenuProps): ReactElement => {
   const [paintbrush, setPaintbrush] = usePaintbrushStore();
+  const [showTransparency, setShowTransparency] = useState(false);
   const classes = useStyles();
 
   function changeBrushRadius(e: ChangeEvent, value: number) {
     setPaintbrush({
       brushType: paintbrush.brushType, // FIXME
       brushRadius: value,
+      annotationAlpha: paintbrush.annotationAlpha,
+      annotationActiveAlpha: paintbrush.annotationActiveAlpha,
     });
   }
 
@@ -71,6 +88,8 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     setPaintbrush({
       brushType: Tools.paintbrush.name,
       brushRadius: paintbrush.brushRadius, // FIXME
+      annotationAlpha: paintbrush.annotationAlpha,
+      annotationActiveAlpha: paintbrush.annotationActiveAlpha,
     });
   }
 
@@ -78,6 +97,34 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     setPaintbrush({
       brushType: Tools.eraser.name,
       brushRadius: paintbrush.brushRadius, // FIXME
+      annotationAlpha: paintbrush.annotationAlpha,
+      annotationActiveAlpha: paintbrush.annotationActiveAlpha,
+    });
+  }
+
+  function toggleShowTransparency() {
+    if (showTransparency) {
+      setShowTransparency(false);
+    } else {
+      setShowTransparency(true);
+    }
+  }
+
+  function changeAnnotationTransparency(e: ChangeEvent, value: number) {
+    setPaintbrush({
+      brushType: paintbrush.brushType,
+      brushRadius: paintbrush.brushRadius, // FIXME
+      annotationAlpha: value,
+      annotationActiveAlpha: paintbrush.annotationActiveAlpha,
+    });
+  }
+
+  function changeAnnotationTransparencyFocused(e: ChangeEvent, value: number) {
+    setPaintbrush({
+      brushType: paintbrush.brushType,
+      brushRadius: paintbrush.brushRadius, // FIXME
+      annotationAlpha: paintbrush.annotationAlpha,
+      annotationActiveAlpha: value,
     });
   }
 
@@ -109,17 +156,44 @@ const Submenu = (props: SubmenuProps): ReactElement => {
             onClick={() => fillBrush()}
             fill={false}
           />
+          <BaseIconButton
+            tooltip={Tools.annotationAlpha}
+            onClick={() => toggleShowTransparency()}
+            fill={showTransparency}
+          />
         </ButtonGroup>
-        <Paper>
-          <div className={classes.baseSlider}>
-            <BaseSlider
-              value={paintbrush.brushRadius}
-              config={SLIDER_CONFIG[Sliders.brushRadius]}
-              onChange={() => changeBrushRadius}
-              showEndValues={false}
-            />
+        <Card className={classes.subMenuCard}>
+          <div className={classes.baseSliderContainer}>
+            <div className={classes.baseSlider}>
+              <BaseSlider
+                value={paintbrush.brushRadius}
+                config={SLIDER_CONFIG[Sliders.brushRadius]}
+                onChange={() => changeBrushRadius}
+                showEndValues={false}
+              />
+            </div>
+            {showTransparency && (
+              <>
+                <div className={classes.baseSlider}>
+                  <BaseSlider
+                    value={paintbrush.annotationAlpha}
+                    config={SLIDER_CONFIG[Sliders.annotationAlpha]}
+                    onChange={() => changeAnnotationTransparency}
+                    showEndValues={false}
+                  />
+                </div>
+                <div className={classes.baseSlider}>
+                  <BaseSlider
+                    value={paintbrush.annotationActiveAlpha}
+                    config={SLIDER_CONFIG[Sliders.annotationActiveAlpha]}
+                    onChange={() => changeAnnotationTransparencyFocused}
+                    showEndValues={false}
+                  />
+                </div>
+              </>
+            )}
           </div>
-        </Paper>
+        </Card>
       </Popover>
     </>
   );

--- a/src/toolboxes/paintbrush/Toolbox.ts
+++ b/src/toolboxes/paintbrush/Toolbox.ts
@@ -19,6 +19,16 @@ const Tools: ToolTips = {
     icon: imgSrc("fill-icon"),
     shortcut: "F",
   },
+  annotationAlpha: {
+    name: "Annotation Transparency",
+    icon: imgSrc("channels-icon"),
+    shortcut: "T",
+  },
+  togglePixels: {
+    name: "Show strokes as pixels?",
+    icon: imgSrc("channels-icon"),
+    shortcut: "P",
+  },
 } as const;
 
 export { ToolboxName, Tools };

--- a/src/toolboxes/paintbrush/configSlider.ts
+++ b/src/toolboxes/paintbrush/configSlider.ts
@@ -2,6 +2,8 @@ import { Config } from "@/components/BaseSlider";
 
 export enum Sliders {
   brushRadius,
+  annotationAlpha,
+  annotationActiveAlpha,
 }
 
 export const SLIDER_CONFIG: {
@@ -15,5 +17,23 @@ export const SLIDER_CONFIG: {
     min: 1,
     max: 20,
     unit: "px",
+  },
+  [Sliders.annotationAlpha]: {
+    name: "annotationAlpha",
+    id: "annotationAlpha-slider",
+    initial: 50,
+    step: 1,
+    min: 0,
+    max: 100,
+    unit: "%",
+  },
+  [Sliders.annotationActiveAlpha]: {
+    name: "annotationActiveAlpha",
+    id: "annotationActiveAlpha-slider",
+    initial: 100,
+    step: 1,
+    min: 0,
+    max: 100,
+    unit: "%",
   },
 } as const;


### PR DESCRIPTION
## Description

~~*HELP WANTED* There are two lint errors on line 237 of `src/toolboxes/background/Toolbar.tsx`. However this was copy and pasted from `src/toolboxes/paintbrush/Toolbar.tsx` where it doesn't cause an error. Any ideas?~~

Adds a new button to the paintbrush toolbar (@joshuajames-smith this will need an icon) that opens two sliders - one for active and one for non-active annotation, both measured in percent.

@joshuajames-smith we need a way to label the sliders nicely because I end up with three unlabelled sliders, which isn't very helpful.

Also, @ChrisBaidoo and @joshuajames-smith aren't we meant to be able to type in the box to change the slider value? Because that doesn't work, out-the-box at least.

~~Currently merging into #318, will rebase when that is merged.~~

closes #283

## Dependency changes

No dependency changes.

Has the pipfile.lock or package-lock.json been updated? No but will version bump when pointed at main.

## Documentation

@philhallbio this will need documenting once @joshuajames-smith has helped out with icons and user flows.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] If appropriate, I have bumped any version numbers
