### PR TITLE
Pixel view

### DIFF
--- a/src/download/DownloadAsTiff.tsx
+++ b/src/download/DownloadAsTiff.tsx
@@ -24,6 +24,9 @@ export function drawCapsule(
   // Each edge can be divided into three part: the top cap, the straight line, the bottom cap.
   const arr = dataSlice;
   const annotationColor = palette[annotationIndex];
+  if (samplesPerPixel === 4) {
+    annotationColor.push(255); // alpha
+  }
 
   const roundXYPoint = (point: XYPoint): XYPoint => ({
     x: Math.round(point.x),

--- a/src/download/DownloadAsTiff.tsx
+++ b/src/download/DownloadAsTiff.tsx
@@ -147,7 +147,7 @@ export function drawCapsule(
         if (x >= 0 && x <= imageWidth) {
           const index = samplesPerPixel * (imageWidth * y + x);
           if (
-            arr.slice(index, index + 3).toString() ===
+            arr.slice(index, index + samplesPerPixel).toString() ===
             annotationColor.toString()
           ) {
             annotationColor.forEach((c, i) => {

--- a/src/download/DownloadAsTiff.tsx
+++ b/src/download/DownloadAsTiff.tsx
@@ -6,7 +6,7 @@ import { XYPoint } from "@/annotation/interfaces";
 import { palette } from "@/components/palette";
 import { Toolboxes } from "@/Toolboxes";
 
-function drawCapsule(
+export function drawCapsule(
   point0: XYPoint,
   point1: XYPoint,
   r: number,

--- a/src/download/DownloadAsTiff.tsx
+++ b/src/download/DownloadAsTiff.tsx
@@ -23,10 +23,10 @@ export function drawCapsule(
   // This means that we must identify the left and right edges of the line.
   // Each edge can be divided into three part: the top cap, the straight line, the bottom cap.
   const arr = dataSlice;
-  const annotationColor = palette[annotationIndex];
-  if (samplesPerPixel === 4) {
-    annotationColor.push(255); // alpha
-  }
+  const annotationColor =
+    samplesPerPixel === 4
+      ? palette[annotationIndex].concat(255) // alpha
+      : palette[annotationIndex];
 
   const roundXYPoint = (point: XYPoint): XYPoint => ({
     x: Math.round(point.x),

--- a/src/keybindings/keybindings.ts
+++ b/src/keybindings/keybindings.ts
@@ -10,6 +10,7 @@ export const keybindings = {
   KeyA: "ui.toggleMode",
   KeyB: "paintbrush.selectBrush",
   KeyE: "paintbrush.selectEraser",
+  KeyP: "paintbrush.togglePixelView",
   KeyS: "spline.selectSpline",
   KeyM: "spline.selectMagicspline",
   KeyD: "download.openDownloadDropdown",

--- a/src/toolboxes/background/drawImage.ts
+++ b/src/toolboxes/background/drawImage.ts
@@ -1,6 +1,6 @@
-function getNewImageSizeAndDisplacement(
+export function getNewImageSizeAndDisplacement(
   ctx: CanvasRenderingContext2D,
-  img: HTMLImageElement | ImageBitmap,
+  img: HTMLImageElement | ImageBitmap | ImageData,
   scaleAndPan: {
     x: number;
     y: number;

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -51,7 +51,6 @@ interface Brush {
 
 interface State {
   hideBackCanvas: boolean;
-  pixelImage: HTMLCanvasElement | null;
   pixelView: boolean;
 }
 
@@ -136,7 +135,6 @@ export class CanvasClass extends Component<Props, State> {
 
     this.state = {
       hideBackCanvas: false,
-      pixelImage: null,
       pixelView: false,
     };
   }
@@ -262,7 +260,7 @@ export class CanvasClass extends Component<Props, State> {
   };
 
   togglePixelView = (): void => {
-    this.setState({ pixelView: !this.state.pixelView });
+    this.setState((oldstate) => ({ pixelView: !oldstate.pixelView }));
   };
 
   drawAllStrokes = (context = this.backgroundCanvas?.canvasContext): void => {

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -323,6 +323,9 @@ export class CanvasClass extends Component<Props, State> {
           imgData,
           this.props.scaleAndPan
         );
+      // // background canvas globalCompositeOperation may still be "destination-out" if
+      // the most recent brushstroke is an eraser, so make sure it's source-over here or else we won't see anything:
+      context.globalCompositeOperation = "source-over";
       context.drawImage(
         this.pixelCanvas,
         offsetX,
@@ -534,7 +537,7 @@ export class CanvasClass extends Component<Props, State> {
           }}
         >
           <div
-            style={{ opacity: this.state.hideBackCanvas ? "none" : "block" }}
+            style={{ opacity: this.state.hideBackCanvas ? "none" : "block" }} // DEVNOTE: this line does nothing!
           >
             <BaseCanvas
               cursor="none"

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -275,6 +275,8 @@ export class CanvasClass extends Component<Props, State> {
     context.clearRect(0, 0, context.canvas.width, context.canvas.height);
 
     if (this.state.pixelView) {
+      // rasterize the brushstrokes and display as image rather than vector:
+
       let img = new Uint8Array(
         4 * this.props.displayedImage.width * this.props.displayedImage.height
       );
@@ -298,6 +300,14 @@ export class CanvasClass extends Component<Props, State> {
           });
         });
 
+      // to get the Uint8Array to render as an image, we need to convert it to ImageData,
+      // then put that in a Canvas, then use drawImage to render that on the paintbrush canvas:
+
+      const imgData = new ImageData(
+        Uint8ClampedArray.from(img),
+        this.props.displayedImage.width
+      );
+
       if (this.pixelCanvas === null) {
         this.pixelCanvas = document.createElement("canvas");
         this.pixelCtx = this.pixelCanvas.getContext("2d");
@@ -305,11 +315,8 @@ export class CanvasClass extends Component<Props, State> {
         this.pixelCanvas.height = this.props.displayedImage.height;
       }
 
-      const imgData = new ImageData(
-        Uint8ClampedArray.from(img),
-        this.props.displayedImage.width
-      );
       this.pixelCtx.putImageData(imgData, 0, 0);
+
       const { offsetX, offsetY, newWidth, newHeight } =
         getNewImageSizeAndDisplacement(
           context,

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -23,6 +23,8 @@ import { Toolboxes, Toolbox } from "@/Toolboxes";
 import { Tools } from "./Toolbox";
 import { usePaintbrushStore } from "./Store";
 import { BrushStroke } from "./interfaces";
+import { drawCapsule } from "@/download/DownloadAsTiff";
+import { getNewImageSizeAndDisplacement } from "@/toolboxes/background/drawImage";
 
 const mainColor = theme.palette.primary.main;
 const secondaryColor = theme.palette.secondary.main;
@@ -49,11 +51,13 @@ interface Brush {
 
 interface State {
   hideBackCanvas: boolean;
+  pixelImage: HTMLCanvasElement | null;
+  pixelView: boolean;
 }
 
 // Here we define the methods that are exposed to be called by keyboard shortcuts
 // We should maybe namespace them so we don't get conflicting methods across toolboxes.
-export const events = ["saveLine", "fillBrush"] as const;
+export const events = ["saveLine", "fillBrush", "togglePixelView"] as const;
 
 interface Event extends CustomEvent {
   type: typeof events[number];
@@ -126,6 +130,8 @@ export class CanvasClass extends Component<Props, State> {
 
     this.state = {
       hideBackCanvas: false,
+      pixelImage: null,
+      pixelView: false,
     };
   }
 
@@ -249,6 +255,10 @@ export class CanvasClass extends Component<Props, State> {
     context.stroke();
   };
 
+  togglePixelView = (): void => {
+    this.setState({ pixelView: !this.state.pixelView });
+  };
+
   drawAllStrokes = (context = this.backgroundCanvas?.canvasContext): void => {
     // Draw strokes on active layer whiles showing existing paintbrush layers
     if (!context) return;
@@ -260,24 +270,68 @@ export class CanvasClass extends Component<Props, State> {
     // Clear paintbrush canvas
     context.clearRect(0, 0, context.canvas.width, context.canvas.height);
 
-    // Draw all paintbrush annotations
-    this.props.annotationsObject
-      .getAllAnnotations()
-      .forEach((annotationsObject, i) => {
-        if (annotationsObject.toolbox === Toolboxes.paintbrush) {
-          annotationsObject.brushStrokes.forEach((brushStrokes) => {
-            if (brushStrokes.spaceTimeInfo.z === this.props.sliceIndex) {
-              this.drawPoints(
-                brushStrokes.coordinates,
-                brushStrokes.brush,
-                false,
-                context,
-                i === activeAnnotationID
+    if (this.state.pixelView) {
+      let img = new Uint8Array(
+        4 * this.props.displayedImage.width * this.props.displayedImage.height
+      );
+      for (let i = 0; i < img.length; i += 1) {
+        img[i] = i % 4 == 3 ? 255 : 0; // set alpha channel to 255
+      }
+      this.props.annotationsObject
+        .getAllAnnotations()
+        .filter(({ toolbox }) => toolbox === Toolboxes.paintbrush)
+        .forEach(({ brushStrokes }, annotationIndex) => {
+          brushStrokes.forEach(({ coordinates, brush }) => {
+            coordinates.forEach((point0, i) => {
+              img = drawCapsule(
+                point0,
+                i + 1 < coordinates.length ? coordinates[i + 1] : point0,
+                brush.radius,
+                img,
+                this.props.displayedImage.width,
+                annotationIndex,
+                brush.type,
+                4
               );
-            }
+            });
           });
-        }
-      });
+        });
+      const pixCanvas = document.createElement("canvas");
+      const pixCtx = pixCanvas.getContext("2d");
+      pixCanvas.width = this.props.displayedImage.width;
+      pixCanvas.height = this.props.displayedImage.height;
+      const imgData = new ImageData(
+        Uint8ClampedArray.from(img),
+        this.props.displayedImage.width
+      );
+      pixCtx.putImageData(imgData, 0, 0);
+      const { offsetX, offsetY, newWidth, newHeight } =
+        getNewImageSizeAndDisplacement(
+          context,
+          imgData,
+          this.props.scaleAndPan
+        );
+      context.drawImage(pixCanvas, offsetX, offsetY, newWidth, newHeight);
+    } else {
+      // Draw all paintbrush annotations
+      this.props.annotationsObject
+        .getAllAnnotations()
+        .forEach((annotationsObject, i) => {
+          if (annotationsObject.toolbox === Toolboxes.paintbrush) {
+            annotationsObject.brushStrokes.forEach((brushStrokes) => {
+              if (brushStrokes.spaceTimeInfo.z === this.props.sliceIndex) {
+                this.drawPoints(
+                  brushStrokes.coordinates,
+                  brushStrokes.brush,
+                  false,
+                  context,
+                  i === activeAnnotationID
+                );
+              }
+            });
+          }
+        });
+    }
   };
 
   getCanvasBrushRadius = (brushRadius: number): number => {

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -274,9 +274,6 @@ export class CanvasClass extends Component<Props, State> {
       let img = new Uint8Array(
         4 * this.props.displayedImage.width * this.props.displayedImage.height
       );
-      for (let i = 0; i < img.length; i += 1) {
-        img[i] = i % 4 == 3 ? 255 : 0; // set alpha channel to 255
-      }
       this.props.annotationsObject
         .getAllAnnotations()
         .filter(({ toolbox }) => toolbox === Toolboxes.paintbrush)

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -111,6 +111,10 @@ export class CanvasClass extends Component<Props, State> {
 
   private backgroundCanvas: BaseCanvas | null;
 
+  private pixelCanvas: HTMLCanvasElement | null;
+
+  private pixelCtx: CanvasRenderingContext2D | null;
+
   private isPressing: boolean;
 
   private isDrawing: boolean;
@@ -127,6 +131,8 @@ export class CanvasClass extends Component<Props, State> {
     this.points = [];
     this.annotationOpacity = this.props.annotationActiveAlpha;
     this.backgroundCanvas = null;
+    this.pixelCanvas = null;
+    this.pixelCtx = null;
 
     this.state = {
       hideBackCanvas: false,
@@ -293,22 +299,32 @@ export class CanvasClass extends Component<Props, State> {
             });
           });
         });
-      const pixCanvas = document.createElement("canvas");
-      const pixCtx = pixCanvas.getContext("2d");
-      pixCanvas.width = this.props.displayedImage.width;
-      pixCanvas.height = this.props.displayedImage.height;
+
+      if (this.pixelCanvas === null) {
+        this.pixelCanvas = document.createElement("canvas");
+        this.pixelCtx = this.pixelCanvas.getContext("2d");
+        this.pixelCanvas.width = this.props.displayedImage.width;
+        this.pixelCanvas.height = this.props.displayedImage.height;
+      }
+
       const imgData = new ImageData(
         Uint8ClampedArray.from(img),
         this.props.displayedImage.width
       );
-      pixCtx.putImageData(imgData, 0, 0);
+      this.pixelCtx.putImageData(imgData, 0, 0);
       const { offsetX, offsetY, newWidth, newHeight } =
         getNewImageSizeAndDisplacement(
           context,
           imgData,
           this.props.scaleAndPan
         );
-      context.drawImage(pixCanvas, offsetX, offsetY, newWidth, newHeight);
+      context.drawImage(
+        this.pixelCanvas,
+        offsetX,
+        offsetY,
+        newWidth,
+        newHeight
+      );
     } else {
       // Draw all paintbrush annotations
       this.props.annotationsObject

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -113,6 +113,9 @@ const Submenu = (props: SubmenuProps): ReactElement => {
 
   function togglePixelView() {
     setPixelView(!pixelView);
+    document.dispatchEvent(
+      new CustomEvent("togglePixelView", { detail: Toolboxes.paintbrush })
+    );
   }
 
   function changeAnnotationTransparency(e: ChangeEvent, value: number) {

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -65,7 +65,9 @@ const useStyles = makeStyles(() =>
 
 const Submenu = (props: SubmenuProps): ReactElement => {
   const [paintbrush, setPaintbrush] = usePaintbrushStore();
-  const [showTransparency, setShowTransparency] = useState(false);
+  const [showTransparency, setShowTransparency] = useState<boolean>(false);
+  const [pixelView, setPixelView] = useState<boolean>(false);
+
   const classes = useStyles();
 
   function changeBrushRadius(e: ChangeEvent, value: number) {
@@ -107,6 +109,10 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     } else {
       setShowTransparency(true);
     }
+  }
+
+  function togglePixelView() {
+    setPixelView(!pixelView);
   }
 
   function changeAnnotationTransparency(e: ChangeEvent, value: number) {
@@ -159,6 +165,13 @@ const Submenu = (props: SubmenuProps): ReactElement => {
             tooltip={Tools.annotationAlpha}
             onClick={() => toggleShowTransparency()}
             fill={showTransparency}
+          />
+          <BaseIconButton
+            tooltip={Tools.togglePixels}
+            onClick={() => {
+              togglePixelView();
+            }}
+            fill={pixelView}
           />
         </ButtonGroup>
         <Card className={classes.subMenuCard}>

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -73,7 +73,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
   function changeBrushRadius(e: ChangeEvent, value: number) {
     setPaintbrush({
       brushType: paintbrush.brushType, // FIXME
-      brushRadius: value,
+      brushRadius: value / 2, // convert from diameter (the displayed size) to radius (what the rest of the codebase expects)
       annotationAlpha: paintbrush.annotationAlpha,
       annotationActiveAlpha: paintbrush.annotationActiveAlpha,
     });
@@ -181,7 +181,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
           <div className={classes.baseSliderContainer}>
             <div className={classes.baseSlider}>
               <BaseSlider
-                value={paintbrush.brushRadius}
+                value={paintbrush.brushRadius * 2}
                 config={SLIDER_CONFIG[Sliders.brushRadius]}
                 onChange={() => changeBrushRadius}
                 showEndValues={false}

--- a/src/toolboxes/paintbrush/Toolbox.ts
+++ b/src/toolboxes/paintbrush/Toolbox.ts
@@ -25,7 +25,7 @@ const Tools: ToolTips = {
     shortcut: "T",
   },
   togglePixels: {
-    name: "Show strokes as pixels?",
+    name: "Show strokes as pixels",
     icon: imgSrc("channels-icon"),
     shortcut: "P",
   },

--- a/src/toolboxes/paintbrush/configSlider.ts
+++ b/src/toolboxes/paintbrush/configSlider.ts
@@ -15,7 +15,7 @@ export const SLIDER_CONFIG: {
     initial: 10,
     step: 1,
     min: 1,
-    max: 20,
+    max: 40,
     unit: "px",
   },
   [Sliders.annotationAlpha]: {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -64,6 +64,7 @@ export const events = [
   "saveAnnotations",
   "undo",
   "redo",
+  "togglePixelView",
 ] as const;
 
 interface State {
@@ -85,6 +86,7 @@ interface State {
   mode: Mode;
   canvasContainerColour: number[];
   canUndoRedo: { undo: boolean; redo: boolean };
+  pixelView: boolean;
 }
 
 const styles = {
@@ -216,6 +218,7 @@ class UserInterface extends Component<Props, State> {
       mode: Mode.draw,
       canvasContainerColour: [255, 255, 255, 1],
       canUndoRedo: { undo: false, redo: false },
+      pixelView: false,
     };
 
     this.annotationsObject.addAnnotation(this.state.activeToolbox);
@@ -651,6 +654,10 @@ class UserInterface extends Component<Props, State> {
   redo = (): void => {
     this.setState({ canUndoRedo: this.annotationsObject.redo() });
     this.callRedraw();
+  };
+
+  togglePixelView = (): void => {
+    this.setState({ pixelView: !this.state.pixelView });
   };
 
   isTyping = (): boolean =>

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -64,7 +64,6 @@ export const events = [
   "saveAnnotations",
   "undo",
   "redo",
-  "togglePixelView",
 ] as const;
 
 interface State {
@@ -86,7 +85,6 @@ interface State {
   mode: Mode;
   canvasContainerColour: number[];
   canUndoRedo: { undo: boolean; redo: boolean };
-  pixelView: boolean;
 }
 
 const styles = {
@@ -218,7 +216,6 @@ class UserInterface extends Component<Props, State> {
       mode: Mode.draw,
       canvasContainerColour: [255, 255, 255, 1],
       canUndoRedo: { undo: false, redo: false },
-      pixelView: false,
     };
 
     this.annotationsObject.addAnnotation(this.state.activeToolbox);
@@ -654,10 +651,6 @@ class UserInterface extends Component<Props, State> {
   redo = (): void => {
     this.setState({ canUndoRedo: this.annotationsObject.redo() });
     this.callRedraw();
-  };
-
-  togglePixelView = (): void => {
-    this.setState({ pixelView: !this.state.pixelView });
   };
 
   isTyping = (): boolean =>


### PR DESCRIPTION
Adds a "pixel view" button in the paintbrush toolbar. I gave up trying to optimize it to only draw new brushstrokes because it'd require a fairly complicated mechanism that wouldn't apply when annotations are deleted or the undo button is used. Fortunately it's reasonably fast drawing from scratch every time; if it becomes prohibitively slow on bigger images then I can do more optimization. 

closes https://github.com/gliff-ai/roadmap/issues/56

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
