### PR TITLE
feat: sharp annotation pixels when using pixelview

### DIFF
--- a/src/toolboxes/background/Canvas.tsx
+++ b/src/toolboxes/background/Canvas.tsx
@@ -45,6 +45,7 @@ export class CanvasClass extends Component<Props, State> {
     if (this.props.displayedImage) {
       this.baseCanvas.canvasContext.globalCompositeOperation =
         "destination-over";
+      this.baseCanvas.canvasContext.imageSmoothingEnabled = false;
       drawImageOnCanvas(
         this.baseCanvas.canvasContext,
         this.props.displayedImage,

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -323,7 +323,7 @@ export class CanvasClass extends Component<Props, State> {
           imgData,
           this.props.scaleAndPan
         );
-      // // background canvas globalCompositeOperation may still be "destination-out" if
+      // background canvas globalCompositeOperation may still be "destination-out" if
       // the most recent brushstroke is an eraser, so make sure it's source-over here or else we won't see anything:
       context.globalCompositeOperation = "source-over";
       context.imageSmoothingEnabled = false;

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -326,6 +326,7 @@ export class CanvasClass extends Component<Props, State> {
       // // background canvas globalCompositeOperation may still be "destination-out" if
       // the most recent brushstroke is an eraser, so make sure it's source-over here or else we won't see anything:
       context.globalCompositeOperation = "source-over";
+      context.imageSmoothingEnabled = false;
       context.drawImage(
         this.pixelCanvas,
         offsetX,


### PR DESCRIPTION
Setting `context.imageSmoothingEnabled = false` on paintbrush and background canvases. This means we see the image pixels as they really are, and the paintbrush pixels as they really are if we're in pixelview mode.