### PR TITLE
Fix eraser

### DIFF
--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -235,6 +235,9 @@ export class CanvasClass extends Component<Props, State> {
       context.strokeStyle = brush.color;
       this.annotationOpacity = this.props.annotationAlpha;
     }
+    if (isActive || brush.type === "erase") {
+      this.annotationOpacity = 1.0;
+    }
     context.globalAlpha = this.annotationOpacity;
 
     if (brush.type === "erase") {

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -235,7 +235,7 @@ export class CanvasClass extends Component<Props, State> {
       context.strokeStyle = brush.color;
       this.annotationOpacity = this.props.annotationAlpha;
     }
-    if (isActive || brush.type === "erase") {
+    if (brush.type === "erase") {
       this.annotationOpacity = 1.0;
     }
     context.globalAlpha = this.annotationOpacity;

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -118,7 +118,7 @@ export class CanvasClass extends Component<Props, State> {
 
   private isDrawing: boolean;
 
-  private points: XYPoint[];
+  private points: XYPoint[]; // buffer of points being drawn by the current mouse stroke
 
   private annotationOpacity: number;
 
@@ -187,12 +187,21 @@ export class CanvasClass extends Component<Props, State> {
       } as Brush;
 
       // Draw current points
-      this.drawPoints(
-        this.points,
-        brush,
-        true,
-        this.interactionCanvas.canvasContext
-      );
+      if (brush.type === "paint") {
+        this.drawPoints(
+          this.points,
+          brush,
+          true,
+          this.interactionCanvas.canvasContext
+        );
+      } else {
+        this.drawPoints(
+          this.points,
+          brush,
+          false,
+          this.backgroundCanvas.canvasContext
+        );
+      }
     }
   };
 


### PR DESCRIPTION
## Description

Eraser strokes are now visible as they're being drawn, not just after. Also fixed a bug where erased portions become visible with translucency when the annotation is inactive.

closes #349 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
