### PR TITLE
Single action drag

### DIFF
--- a/src/toolboxes/boundingBox/Canvas.tsx
+++ b/src/toolboxes/boundingBox/Canvas.tsx
@@ -59,6 +59,8 @@ export class CanvasClass extends Component<Props> {
 
   private isMouseDown: boolean;
 
+  private dragCoords: BoundingBoxCoordinates; // holds the box's transient state as we drag a corner, since it's not committed to annotationsObject until we release
+
   constructor(props: Props) {
     super(props);
     this.selectedCorner = "none";
@@ -144,7 +146,14 @@ export class CanvasClass extends Component<Props> {
     }
 
     // get the four corners
-    const { topLeft, bottomRight } = boundingBoxCoordinates;
+    let topLeft, bottomRight;
+    if (this.isMouseDown && isActive) {
+      topLeft = this.dragCoords.topLeft;
+      bottomRight = this.dragCoords.bottomRight;
+    } else {
+      topLeft = boundingBoxCoordinates.topLeft;
+      bottomRight = boundingBoxCoordinates.bottomRight;
+    }
     const topRight: XYPoint = { x: topLeft?.x, y: bottomRight?.y };
     const bottomLeft: XYPoint = { x: bottomRight?.x, y: topLeft?.y };
     const corners: XYPoint[] = [topLeft, topRight, bottomRight, bottomLeft];
@@ -495,6 +504,7 @@ export class CanvasClass extends Component<Props> {
       // which actually doesnt exist but is a powerful feature to add
       this.selectedCorner = nearPoint;
       this.isMouseDown = true;
+      this.dragCoords = boundingBoxCoordinates;
     }
 
     this.drawAllBoundingBoxes();
@@ -530,9 +540,6 @@ export class CanvasClass extends Component<Props> {
             },
             { x: clickPoint.x, y: clickPoint.y } // prevents us overwriting the original click point
           );
-          this.props.annotationsObject.updateBoundingBoxCoordinates(
-            boundingBoxCoordinates
-          );
           break;
         case "topRight":
           boundingBoxCoordinates = this.orderCoordinates(
@@ -541,9 +548,6 @@ export class CanvasClass extends Component<Props> {
               y: boundingBoxCoordinates.topLeft.y,
             },
             { x: clickPoint.x, y: clickPoint.y } // prevents us overwriting the original click point
-          );
-          this.props.annotationsObject.updateBoundingBoxCoordinates(
-            boundingBoxCoordinates
           );
           break;
         case "bottomRight":
@@ -554,9 +558,6 @@ export class CanvasClass extends Component<Props> {
             },
             { x: clickPoint.x, y: clickPoint.y } // prevents us overwriting the original click point
           );
-          this.props.annotationsObject.updateBoundingBoxCoordinates(
-            boundingBoxCoordinates
-          );
           break;
         case "bottomLeft":
           boundingBoxCoordinates = this.orderCoordinates(
@@ -566,13 +567,11 @@ export class CanvasClass extends Component<Props> {
             },
             { x: clickPoint.x, y: clickPoint.y } // prevents us overwriting the original click point
           );
-          this.props.annotationsObject.updateBoundingBoxCoordinates(
-            boundingBoxCoordinates
-          );
           break;
         default:
           break;
       }
+      this.dragCoords = boundingBoxCoordinates;
     }
 
     // Redraw all the splines
@@ -581,7 +580,12 @@ export class CanvasClass extends Component<Props> {
 
   onMouseUp = (): void => {
     // Works as part of drag and drop for points.
-    this.isMouseDown = false;
+    if (this.isMouseDown) {
+      this.props.annotationsObject.updateBoundingBoxCoordinates(
+        this.dragCoords
+      );
+      this.isMouseDown = false;
+    }
   };
 
   isComplete = (boundingBoxCoordinates: BoundingBoxCoordinates): boolean =>

--- a/src/toolboxes/boundingBox/Canvas.tsx
+++ b/src/toolboxes/boundingBox/Canvas.tsx
@@ -146,13 +146,12 @@ export class CanvasClass extends Component<Props> {
     }
 
     // get the four corners
-    let topLeft, bottomRight;
+    let topLeft;
+    let bottomRight;
     if (this.isMouseDown && isActive) {
-      topLeft = this.dragCoords.topLeft;
-      bottomRight = this.dragCoords.bottomRight;
+      ({ topLeft, bottomRight } = this.dragCoords);
     } else {
-      topLeft = boundingBoxCoordinates.topLeft;
-      bottomRight = boundingBoxCoordinates.bottomRight;
+      ({ topLeft, bottomRight } = boundingBoxCoordinates);
     }
     const topRight: XYPoint = { x: topLeft?.x, y: bottomRight?.y };
     const bottomLeft: XYPoint = { x: bottomRight?.x, y: topLeft?.y };

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -122,7 +122,7 @@ class CanvasClass extends Component<Props> {
       if (isActive && this.selectedPointIndex === 0 && this.isMouseDown) {
         firstPoint = this.dragPoint;
       } else {
-        firstPoint = splineVector[0];
+        firstPoint = splineVector[0]; // eslint-disable-line prefer-destructuring
       }
 
       firstPoint = imageToCanvas(
@@ -602,8 +602,6 @@ class CanvasClass extends Component<Props> {
       this.props.scaleAndPan,
       this.props.canvasPositionAndSize
     );
-
-    const coordinates = this.props.annotationsObject.getSplineCoordinates();
 
     if (
       this.props.activeToolbox === Tools.magicspline.name &&

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -53,6 +53,8 @@ class CanvasClass extends Component<Props> {
 
   private isMouseDown: boolean;
 
+  private dragPoint: XYPoint; // current position of dragged point
+
   private gradientImage: ImageData;
 
   private numberOfMoves: number; // increments on mouse move; used to space out the magic spline points
@@ -116,7 +118,13 @@ class CanvasClass extends Component<Props> {
 
     if (splineVector.length > 1) {
       // Go to the first point
-      let firstPoint: XYPoint = splineVector[0];
+      let firstPoint: XYPoint;
+      if (isActive && this.selectedPointIndex === 0 && this.isMouseDown) {
+        firstPoint = this.dragPoint;
+      } else {
+        firstPoint = splineVector[0];
+      }
+
       firstPoint = imageToCanvas(
         firstPoint.x,
         firstPoint.y,
@@ -130,10 +138,23 @@ class CanvasClass extends Component<Props> {
       context.moveTo(firstPoint.x, firstPoint.y);
 
       // Draw each point by taking our raw coordinates and applying the transform so they fit on our canvas
-      for (const { x, y } of splineVector) {
+      for (const [idx, { x, y }] of splineVector.entries()) {
+        let drawPoint: XYPoint;
+        if (
+          isActive &&
+          this.isMouseDown &&
+          (idx === this.selectedPointIndex ||
+            (idx === splineVector.length - 1 && // make sure to draw the final point at this.dragPoint if the spline is closed and we're dragging the first point
+              this.isClosed(splineVector) &&
+              this.selectedPointIndex === 0))
+        ) {
+          drawPoint = this.dragPoint;
+        } else {
+          drawPoint = { x, y };
+        }
         nextPoint = imageToCanvas(
-          x,
-          y,
+          drawPoint.x,
+          drawPoint.y,
           this.props.displayedImage.width,
           this.props.displayedImage.height,
           this.props.scaleAndPan,
@@ -148,9 +169,22 @@ class CanvasClass extends Component<Props> {
     context.beginPath();
     splineVector.forEach(({ x, y }, i) => {
       if (i !== splineVector.length - 1 || !this.isClosed(splineVector)) {
+        let drawPoint: XYPoint;
+        if (
+          isActive &&
+          this.isMouseDown &&
+          (i === this.selectedPointIndex ||
+            (i === splineVector.length - 1 && // make sure to draw the final point at this.dragPoint if the spline is closed and we're dragging the first point
+              this.isClosed(splineVector) &&
+              this.selectedPointIndex === 0))
+        ) {
+          drawPoint = this.dragPoint;
+        } else {
+          drawPoint = { x, y };
+        }
         nextPoint = imageToCanvas(
-          x,
-          y,
+          drawPoint.x,
+          drawPoint.y,
           this.props.displayedImage.width,
           this.props.displayedImage.height,
           this.props.scaleAndPan,
@@ -280,6 +314,12 @@ class CanvasClass extends Component<Props> {
     // handle click to select an annotation (Mode.select)
     // or add new point to a normal spline (Mode.draw and this.props.activeToolbox === Tools.spline.name)
     // or add TL or BR point to a rectangle spline (Mode.draw and this.props.activeToolbox === Tools.rectspline.name)
+
+    if (this.isMouseDown) {
+      // turns out onClick still runs when releasing a drag, so we want to abort in that case:
+      this.isMouseDown = false;
+      return;
+    }
 
     // X and Y are in CanvasSpace, convert to ImageSpace
     const { x: imageX, y: imageY } = canvasToImage(
@@ -542,6 +582,7 @@ class CanvasClass extends Component<Props> {
       if (nearPoint !== -1) {
         this.selectedPointIndex = nearPoint;
         this.isMouseDown = true;
+        this.dragPoint = clickPoint;
       }
     }
     this.drawAllSplines();
@@ -590,20 +631,8 @@ class CanvasClass extends Component<Props> {
       this.selectedPointIndex =
         this.props.annotationsObject.getSplineLength() - 1;
     } else {
-      // normal spline, if dragging first point, update closed last
-      if (this.selectedPointIndex === 0 && this.isClosed(coordinates)) {
-        this.props.annotationsObject.updateSplinePoint(
-          clickPoint.x,
-          clickPoint.y,
-          this.props.annotationsObject.getSplineLength() - 1
-        );
-      }
-
-      this.props.annotationsObject.updateSplinePoint(
-        clickPoint.x,
-        clickPoint.y,
-        this.selectedPointIndex
-      );
+      // dragging a point on a normal spline
+      this.dragPoint = clickPoint;
     }
 
     // Redraw all the splines
@@ -612,7 +641,23 @@ class CanvasClass extends Component<Props> {
 
   onMouseUp = (): void => {
     // Works as part of drag and drop for points.
-    this.isMouseDown = false;
+    if (this.isMouseDown) {
+      const coords = this.props.annotationsObject.getSplineCoordinates();
+      if (this.isClosed(coords)) {
+        this.props.annotationsObject.updateSplinePoint(
+          this.dragPoint.x,
+          this.dragPoint.y,
+          coords.length - 1
+        );
+      }
+      this.props.annotationsObject.updateSplinePoint(
+        this.dragPoint.x,
+        this.dragPoint.y,
+        this.selectedPointIndex
+      );
+    }
+    // we set this.isMouseDown = false in onClick
+    // onMouseUp runs before onClick, so if we set it here then onClick wouldn't know to abort
   };
 
   isClosed = (splineVector: XYPoint[]): boolean =>


### PR DESCRIPTION
## Description

Updates `annotationsObject` only once when a dragged point is released, instead of on every `onMouseMove`. Committing every mouse move meant that the audit was spammed with unnecessary actions and the undo stack regarded each mouse move as a separate action to undo, so it took a hundred undo clicks to undo a drag. Did this for both splines and bounding boxes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
