### PR TITLE
Closed spline flag

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -484,6 +484,11 @@ export class Annotations {
     const color = this.getActiveAnnotationColor(); // FIXME always green
     const labels = this.getLabels();
     const spaceTimeInfo = this.getSplineSpaceTimeInfo();
+
+    if (this.splineIsClosed()) {
+      coordinates.push(coordinates[0]);
+    }
+
     const brushStroke: BrushStroke = {
       coordinates,
       spaceTimeInfo,

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -55,6 +55,7 @@ export class Annotations {
     spline: Spline = {
       coordinates: [],
       spaceTimeInfo: { z: 0, t: 0 },
+      isClosed: false,
     },
     boundingBox: BoundingBox = {
       coordinates: {
@@ -320,6 +321,11 @@ export class Annotations {
     return splines;
   };
 
+  splineIsClosed(id: number = null): boolean {
+    const spline = this.data[id ? id : this.activeAnnotationID].spline;
+    return spline.isClosed;
+  }
+
   @log
   clearSplineCoordinates(addToUndoRedo = true): void {
     const oldCoords = JSON.parse(
@@ -405,6 +411,15 @@ export class Annotations {
       z: z || prevZ,
       t: t || prevT,
     };
+  }
+
+  @log
+  setSplineClosed(closed: boolean, addToUndoRedo = true): void {
+    this.data[this.activeAnnotationID].spline.isClosed = closed;
+    if (addToUndoRedo) {
+      this.updateUndoRedoActions("setSplineClosed", [!closed]);
+      this.redoData = [];
+    }
   }
 
   clickNearSpline = (

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -322,7 +322,7 @@ export class Annotations {
   };
 
   splineIsClosed(id: number = null): boolean {
-    const spline = this.data[id ? id : this.activeAnnotationID].spline;
+    const { spline } = this.data[id || this.activeAnnotationID];
     return spline.isClosed;
   }
 

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -590,6 +590,9 @@ class CanvasClass extends Component<Props> {
   private addNewPointNearSpline = (x: number, y: number): void => {
     // Add a new point near the spline.
     const coordinates = this.props.annotationsObject.getSplineCoordinates();
+    if (this.props.annotationsObject.splineIsClosed()) {
+      coordinates.push(coordinates[0]); // add the closing edge if the spline is closed
+    }
 
     const dist = (x1: number, y1: number, x2: number, y2: number): number =>
       // Calculate Euclidean distance between two points (x1, y1) and (x2, y2).
@@ -603,15 +606,17 @@ class CanvasClass extends Component<Props> {
       // Calculate the euclidean distance from the new point
       const newDist =
         dist(x, y, prevPoint.x, prevPoint.y) +
-        dist(x, y, nextPoint.x, nextPoint.y);
+        dist(x, y, nextPoint.x, nextPoint.y) -
+        dist(prevPoint.x, prevPoint.y, nextPoint.x, nextPoint.y);
       // If the calculated distance is smaller than the min distance so far
-      if (minDist > newDist) {
+      if (newDist < minDist) {
         // Update minimum distance and new point index
         minDist = newDist;
         newPointIndex = i;
       }
     }
     this.props.annotationsObject.insertSplinePoint(newPointIndex, { x, y }); // Add new point to the coordinates array
+    this.selectedPointIndex = newPointIndex;
   };
 
   getCursor = (): Cursor => {

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -140,14 +140,8 @@ class CanvasClass extends Component<Props> {
       // Draw each point by taking our raw coordinates and applying the transform so they fit on our canvas
       for (const [idx, { x, y }] of splineVector.entries()) {
         let drawPoint: XYPoint;
-        if (
-          isActive &&
-          this.isMouseDown &&
-          (idx === this.selectedPointIndex ||
-            (idx === splineVector.length - 1 && // make sure to draw the final point at this.dragPoint if the spline is closed and we're dragging the first point
-              this.isClosed(splineVector) &&
-              this.selectedPointIndex === 0))
-        ) {
+        if (isActive && this.isMouseDown && idx === this.selectedPointIndex) {
+          // draw the point at the current mouse position if we're dragging it:
           drawPoint = this.dragPoint;
         } else {
           drawPoint = { x, y };
@@ -162,49 +156,43 @@ class CanvasClass extends Component<Props> {
         );
         context.lineTo(nextPoint.x, nextPoint.y);
       }
+      if (this.props.annotationsObject.splineIsClosed()) {
+        context.lineTo(firstPoint.x, firstPoint.y);
+      }
       context.stroke();
     }
 
     // Draw all points
     context.beginPath();
     splineVector.forEach(({ x, y }, i) => {
-      if (i !== splineVector.length - 1 || !this.isClosed(splineVector)) {
-        let drawPoint: XYPoint;
-        if (
-          isActive &&
-          this.isMouseDown &&
-          (i === this.selectedPointIndex ||
-            (i === splineVector.length - 1 && // make sure to draw the final point at this.dragPoint if the spline is closed and we're dragging the first point
-              this.isClosed(splineVector) &&
-              this.selectedPointIndex === 0))
-        ) {
-          drawPoint = this.dragPoint;
-        } else {
-          drawPoint = { x, y };
-        }
-        nextPoint = imageToCanvas(
-          drawPoint.x,
-          drawPoint.y,
-          this.props.displayedImage.width,
-          this.props.displayedImage.height,
-          this.props.scaleAndPan,
-          this.props.canvasPositionAndSize
-        );
-        if (this.selectedPointIndex === i && isActive) {
-          context.fillRect(
-            nextPoint.x - pointSize / 2,
-            nextPoint.y - pointSize / 2,
-            pointSize,
-            pointSize
-          ); // draw a filled square to mark the point as selected
-        } else {
-          context.rect(
-            nextPoint.x - pointSize / 2,
-            nextPoint.y - pointSize / 2,
-            pointSize,
-            pointSize
-          ); // draw a square to mark the point
-        }
+      let drawPoint: XYPoint;
+      if (isActive && this.isMouseDown && i === this.selectedPointIndex) {
+        drawPoint = this.dragPoint;
+      } else {
+        drawPoint = { x, y };
+      }
+      nextPoint = imageToCanvas(
+        drawPoint.x,
+        drawPoint.y,
+        this.props.displayedImage.width,
+        this.props.displayedImage.height,
+        this.props.scaleAndPan,
+        this.props.canvasPositionAndSize
+      );
+      if (this.selectedPointIndex === i && isActive) {
+        context.fillRect(
+          nextPoint.x - pointSize / 2,
+          nextPoint.y - pointSize / 2,
+          pointSize,
+          pointSize
+        ); // draw a filled square to mark the point as selected
+      } else {
+        context.rect(
+          nextPoint.x - pointSize / 2,
+          nextPoint.y - pointSize / 2,
+          pointSize,
+          pointSize
+        ); // draw a square to mark the point
       }
     });
     context.stroke();
@@ -240,37 +228,16 @@ class CanvasClass extends Component<Props> {
   deleteSelectedPoint = (): void => {
     if (this.selectedPointIndex === -1 || !this.sliceIndexMatch()) return;
 
-    const coordinates = this.props.annotationsObject.getSplineCoordinates();
-    const isClosed = this.isClosed(coordinates);
+    // Delete x,y point at selected index
+    this.props.annotationsObject.deleteSplinePoint(this.selectedPointIndex);
 
-    // If close spline
-    if (isClosed) {
-      // If selected index is last index, change selected index to first index
-      if (this.selectedPointIndex === coordinates.length - 1) {
-        this.selectedPointIndex = 0;
-      }
+    // decrement selectedPointIndex, unless it's already 0:
+    this.selectedPointIndex = Math.max(0, this.selectedPointIndex - 1);
 
-      // Delete x,y point at selected index
-      this.props.annotationsObject.deleteSplinePoint(this.selectedPointIndex);
-
-      // If selected index is first index, delete also point at last index
-      if (this.selectedPointIndex === 0) {
-        if (this.props.annotationsObject.getSplineLength() === 1) {
-          this.props.annotationsObject.clearSplineCoordinates();
-        } else {
-          this.props.annotationsObject.updateSplinePoint(
-            coordinates[1].x, // coordinates is outdated here due to deleteSplinePoint; coordinates[1] is therefore coordinates[0] now that we've deleted the previous first point
-            coordinates[1].y,
-            this.props.annotationsObject.getSplineLength() - 1
-          );
-        }
-      }
-    } else {
-      // Delete x,y point at selected index
-      this.props.annotationsObject.deleteSplinePoint(this.selectedPointIndex);
+    if (this.props.annotationsObject.getSplineCoordinates().length < 3) {
+      this.props.annotationsObject.setSplineClosed(false);
     }
 
-    this.selectedPointIndex = Math.max(0, this.selectedPointIndex - 1);
     this.drawAllSplines();
   };
 
@@ -358,8 +325,6 @@ class CanvasClass extends Component<Props> {
           { x: imageX, y: imageY },
           coordinates
         );
-        // check if the current spline is a closed one
-        const isClosed = this.isClosed(coordinates);
 
         if (nudgePointIdx !== -1) {
           // If the mouse click was near an existing point, nudge that point
@@ -370,17 +335,10 @@ class CanvasClass extends Component<Props> {
             (nudgePoint.y + imageY) / 2,
             nudgePointIdx
           );
-
-          if (nudgePointIdx === 0 && isClosed) {
-            // need to update the final point as well if we're nudging the first point of a closed spline,
-            // or else the loop gets broken
-            this.props.annotationsObject.updateSplinePoint(
-              (nudgePoint.x + imageX) / 2,
-              (nudgePoint.y + imageY) / 2,
-              coordinates.length - 1
-            );
-          }
-        } else if (this.props.mode === Mode.draw && !isClosed) {
+        } else if (
+          this.props.mode === Mode.draw &&
+          !this.props.annotationsObject.splineIsClosed()
+        ) {
           // else, i.e. not near an existing point
           // if the spline is not closed and we are in Mode.draw then
           // add coordinates to the current spline
@@ -423,32 +381,28 @@ class CanvasClass extends Component<Props> {
       return; // need at least three points to make a closed polygon
     }
 
-    if (this.isClosed(coordinates)) {
-      return; // don't duplicate the first point again if the loop is already closed
-    }
-
-    // add an endpoint that is the same as the startpoint
-    this.props.annotationsObject.addSplinePoint(coordinates[0]);
+    this.props.annotationsObject.setSplineClosed(true);
 
     this.drawAllSplines();
   };
 
-  convertSpline = (): void => {
-    // Create a new paintbrush annotation that is equivalent to closing and filling the current spline shape
+  convertSpline = (): boolean => {
+    // Create a new paintbrush annotation that is equivalent to closing the current spline shape
+    // Returns true if successful, false otherwise
 
     if (
       this.props.activeToolbox !== Tools.spline.name &&
       this.props.activeToolbox !== Tools.lassospline.name &&
       this.props.activeToolbox !== Tools.magicspline.name
     )
-      return;
+      return false;
 
     // check the current annotation is on the current slice
-    if (!this.sliceIndexMatch()) return;
+    if (!this.sliceIndexMatch()) return false;
 
     // convert to paintbrush annotation with diameter=1 pixel
     // TODO determine radius more cleverly
-    this.props.annotationsObject.convertSplineToPaintbrush(2);
+    this.props.annotationsObject.convertSplineToPaintbrush(0.5);
 
     // set the active tool to be the paintbrush
     document.dispatchEvent(
@@ -456,36 +410,19 @@ class CanvasClass extends Component<Props> {
     );
 
     this.drawAllSplines();
+
+    return true;
   };
 
   fillSpline = (): void => {
     // Create a new paintbrush annotation that is equivalent to closing and filling the current spline shape
 
-    if (
-      this.props.activeToolbox !== Tools.spline.name &&
-      this.props.activeToolbox !== Tools.lassospline.name &&
-      this.props.activeToolbox !== Tools.magicspline.name
-    )
-      return;
-
-    // check the current annotation is on the current slice
-    if (!this.sliceIndexMatch()) return;
-
-    // convert to paintbrush annotation with diameter=1 pixel
-    // TODO determine radius more cleverly
-    this.props.annotationsObject.convertSplineToPaintbrush(2);
-
-    // call the fill paintbrush function
-    document.dispatchEvent(
-      new CustomEvent("fillBrush", { detail: Toolboxes.paintbrush })
-    );
-
-    // set the active tool to be the paintbrush
-    document.dispatchEvent(
-      new CustomEvent("selectBrush", { detail: Toolboxes.paintbrush })
-    );
-
-    this.drawAllSplines();
+    if (this.convertSpline()) {
+      // call the fill paintbrush function
+      document.dispatchEvent(
+        new CustomEvent("fillBrush", { detail: Toolboxes.paintbrush })
+      );
+    }
   };
 
   snapToGradient = (idx: number, snapeRadius = 25): void => {
@@ -640,14 +577,6 @@ class CanvasClass extends Component<Props> {
   onMouseUp = (): void => {
     // Works as part of drag and drop for points.
     if (this.isMouseDown) {
-      const coords = this.props.annotationsObject.getSplineCoordinates();
-      if (this.isClosed(coords)) {
-        this.props.annotationsObject.updateSplinePoint(
-          this.dragPoint.x,
-          this.dragPoint.y,
-          coords.length - 1
-        );
-      }
       this.props.annotationsObject.updateSplinePoint(
         this.dragPoint.x,
         this.dragPoint.y,
@@ -657,12 +586,6 @@ class CanvasClass extends Component<Props> {
     // we set this.isMouseDown = false in onClick
     // onMouseUp runs before onClick, so if we set it here then onClick wouldn't know to abort
   };
-
-  isClosed = (splineVector: XYPoint[]): boolean =>
-    // Check whether the spline is a closed loop.
-    splineVector.length > 1 &&
-    splineVector[0].x === splineVector[splineVector.length - 1].x &&
-    splineVector[0].y === splineVector[splineVector.length - 1].y;
 
   private addNewPointNearSpline = (x: number, y: number): void => {
     // Add a new point near the spline.

--- a/src/toolboxes/spline/interfaces.ts
+++ b/src/toolboxes/spline/interfaces.ts
@@ -3,4 +3,5 @@ import { XYPoint, ZTPoint } from "@/annotation/interfaces";
 export interface Spline {
   coordinates: XYPoint[];
   spaceTimeInfo: ZTPoint;
+  isClosed: boolean;
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -444,13 +444,13 @@ class UserInterface extends Component<Props, State> {
   };
 
   setUploadedImage = (
-    imageFileInfo: ImageFileInfo,
-    slicesData: Array<Array<ImageBitmap>>
+    imageFileInfo: ImageFileInfo[],
+    slicesData: ImageBitmap[][][]
   ): void => {
     if (!this.props.isUserOwner) return;
 
-    this.imageFileInfo = imageFileInfo;
-    this.slicesData = slicesData;
+    [this.imageFileInfo] = imageFileInfo;
+    [this.slicesData] = slicesData;
     this.setState(
       {
         sliceIndex: 0,

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -451,6 +451,7 @@ class UserInterface extends Component<Props, State> {
 
     [this.imageFileInfo] = imageFileInfo;
     [this.slicesData] = slicesData;
+
     this.setState(
       {
         sliceIndex: 0,


### PR DESCRIPTION
## Description

Instead of duplicating the first point on the end of the spline, now represents closed splines with a flag in the `Spline` interface. Ended up removing around 80 lines from spline canvas, and the undo edge cases are now fixed.

Also fixed the brush radius in `convertSpline`, removed redundant code in `fillSpline`, and fixed an edge case involving long edges in `addNewPointNearSpline`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
