### PR TITLE
Fix uninitialized undo

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -46,6 +46,7 @@ export class Annotations {
     this.data = data || [];
     this.audit = audit || [];
     this.activeAnnotationID = 0;
+    this.initUndoRedo();
   }
 
   @log

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -244,10 +244,6 @@ class UserInterface extends Component<Props, State> {
       prevProps.annotationsObject !== this.props.annotationsObject
     ) {
       this.annotationsObject = this.props.annotationsObject;
-      // Restore activeAnnotationID
-      this.annotationsObject.setActiveAnnotationID(
-        this.state.activeAnnotationID
-      );
       this.callRedraw();
     }
   };


### PR DESCRIPTION
## Description

This *should* fix the Sentry error page @ChasNelson1990 and @philhallbio  were getting when loading an image with saved annotation. It's an intermittent bug that happens only when fetching the annotations object from etebase takes sufficiently long that it doesn't get passed in until after the ANNOTATE `UserInterface` constructor has already run, so would be good if people could test this one a bit before approving. I think the bounding box association was purely coincidental, since I've been able to replicate the bug without using bounding boxes and they're not involved in any mechanism I can think of for this disease state.

EDIT: I've also removed the `setActiveAnnotationID` call that was causing the bug when a new `Annotations` was passed in - it shouldn't cause the bug anymore but I removed it anyway because it doesn't seem to be necessary anymore. It's supposed to prevent the active annotation resetting to the first one when you hit save, but I *think* that's something that was needed 4 months ago when it was added but not now, so if you're testing this, try adding some annotations and hit save, and see if the active annotation changes (it shouldn't).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
