### PR TITLE
fix: Amended Paintbrush Name in IconButton

### DIFF
--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -344,7 +344,7 @@ class Toolbar extends Component<Props> {
       <ButtonGroup style={{ all: "revert" }}>
         <IconButton
           tooltip={{
-            name: "Paintbush",
+            name: "Paintbrush",
             ...getShortcut("paintbrush.selectBrush"),
           }}
           icon={icons.brush}


### PR DESCRIPTION
## Description

Paintbrush was named incorrectly in the toolbar.

## Dependency changes

No

## Testing

No

## Documentation

No

## Migrations (if applicable)

No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
