### PR TITLE
feat: add 3D paintbrushes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9936,6 +9936,7 @@
       "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
       "dev": true,
       "requires": {
+        "@oclif/config": "^1.15.1",
         "@oclif/errors": "^1.3.3",
         "@oclif/parser": "^3.8.3",
         "@oclif/plugin-help": "^3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@gliff-ai/eslint-config": "^0.1.3",
-        "@gliff-ai/style": "^2.2.1",
+        "@gliff-ai/style": "^2.3.0",
         "@material-ui/core": "^4.11.3",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.58",
@@ -811,9 +811,9 @@
       "integrity": "sha512-PsCPLF6s66nY56Gr/W+bRTM85wJ/IDdXYU2D7c4bnsQ9dzqWDDuoDx6m9wrJjmr6kxtQxMnfHr915tl8lTA5mw=="
     },
     "node_modules/@gliff-ai/style": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-2.2.1.tgz",
-      "integrity": "sha512-0z8pnV75dNempGXseI/HJ6E5vkqBK1QqBzDRfBMjcWWRkoLGDe2fgAs85rwPROcgU7fJLr4JeEJge680EXn6wg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-2.3.0.tgz",
+      "integrity": "sha512-y8ugrRwGA2GG/QrL3tGZzaazRX3PByznWjpC69a8nt0o7BUFRExHxIHvbwovuI5Svr+yDn2Nwp5B1OnJ5M8MEg==",
       "dev": true,
       "dependencies": {
         "react-inlinesvg": "^2.3.0"
@@ -9438,9 +9438,9 @@
       "integrity": "sha512-PsCPLF6s66nY56Gr/W+bRTM85wJ/IDdXYU2D7c4bnsQ9dzqWDDuoDx6m9wrJjmr6kxtQxMnfHr915tl8lTA5mw=="
     },
     "@gliff-ai/style": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-2.2.1.tgz",
-      "integrity": "sha512-0z8pnV75dNempGXseI/HJ6E5vkqBK1QqBzDRfBMjcWWRkoLGDe2fgAs85rwPROcgU7fJLr4JeEJge680EXn6wg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-2.3.0.tgz",
+      "integrity": "sha512-y8ugrRwGA2GG/QrL3tGZzaazRX3PByznWjpC69a8nt0o7BUFRExHxIHvbwovuI5Svr+yDn2Nwp5B1OnJ5M8MEg==",
       "dev": true,
       "requires": {
         "react-inlinesvg": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "AGPL-3.0-only",
   "devDependencies": {
     "@gliff-ai/eslint-config": "^0.1.3",
-    "@gliff-ai/style": "^2.2.1",
+    "@gliff-ai/style": "^2.3.0",
     "@material-ui/core": "^4.11.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -485,7 +485,7 @@ export class Annotations {
     this.data[this.activeAnnotationID].spline?.spaceTimeInfo;
 
   @log
-  convertSplineToPaintbrush(radius: number): void {
+  convertSplineToPaintbrush(radius: number, is3D = false): void {
     const coordinates = this.getSplineCoordinates();
     const color = this.getActiveAnnotationColor(); // FIXME always green
     const labels = this.getLabels();
@@ -502,6 +502,7 @@ export class Annotations {
         radius,
         type: "paint",
         color,
+        is3D,
       },
     };
     this.deleteActiveAnnotation();

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -22,6 +22,7 @@ const mainColor = theme.palette.primary.main;
 
 interface Props extends Omit<CanvasProps, "canvasPositionAndSize"> {
   isActive: boolean;
+  is3D: boolean;
   activeToolbox: Toolbox | string;
   mode: Mode;
   annotationsObject: Annotations;
@@ -352,6 +353,7 @@ export class CanvasClass extends Component<Props, State> {
         color,
         radius,
         type: this.props.activeToolbox === "Paintbrush" ? "paint" : "erase",
+        is3D: this.props.is3D,
       },
     });
 
@@ -394,6 +396,7 @@ export class CanvasClass extends Component<Props, State> {
           color,
           radius: 1,
           type: "paint",
+          is3D: this.props.is3D,
         },
       };
 
@@ -607,7 +610,11 @@ export class CanvasClass extends Component<Props, State> {
 export const Canvas = (
   props: Omit<
     Props,
-    "brushRadius" | "isActive" | "annotationAlpha" | "annotationActiveAlpha"
+    | "brushRadius"
+    | "isActive"
+    | "annotationAlpha"
+    | "annotationActiveAlpha"
+    | "is3D"
   >
 ): ReactElement => {
   // we will overwrite props.activeToolbox, which will be paintbrush
@@ -619,11 +626,12 @@ export const Canvas = (
     activeToolbox = paintbrush.brushType;
     isActive = true;
   }
-  // we will also use the brushRadius that's in the store
 
+  // we also use the brushRadius and is3D that's in the store
   return (
     <CanvasClass
       isActive={isActive}
+      is3D={paintbrush.is3D}
       activeToolbox={activeToolbox}
       mode={props.mode}
       annotationsObject={props.annotationsObject}

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -14,12 +14,11 @@ import {
 import { palette, getRGBAString } from "@/components/palette";
 import { Toolboxes, Toolbox } from "@/Toolboxes";
 import { usePaintbrushStore } from "./Store";
-import { BrushStroke } from "./interfaces";
+import { Brush, BrushStroke } from "./interfaces";
 import { drawCapsule } from "@/download/DownloadAsTiff";
 import { getNewImageSizeAndDisplacement } from "@/toolboxes/background/drawImage";
 
 const mainColor = theme.palette.primary.main;
-// const secondaryColor = theme.palette.secondary.main;
 
 interface Props extends Omit<CanvasProps, "canvasPositionAndSize"> {
   isActive: boolean;
@@ -33,12 +32,6 @@ interface Props extends Omit<CanvasProps, "canvasPositionAndSize"> {
   sliceIndex: number;
   setUIActiveAnnotationID: (id: number) => void;
   setActiveToolbox: (tool: Toolbox) => void;
-}
-
-interface Brush {
-  radius: number;
-  type: "paint" | "erase";
-  color: string; // rgb(a) string
 }
 
 interface State {

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -223,7 +223,6 @@ export class CanvasClass extends Component<Props, State> {
     // Draw strokes on active layer whiles showing existing paintbrush layers
     // drawWhich: "all" (default), "active", "inactive"
 
-    // const context = this.backgroundCanvas?.canvasContext;
     if (!context) return;
 
     // Clear paintbrush canvas

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -459,19 +459,6 @@ export class CanvasClass extends Component<Props, State> {
         // Redraw the active annotation:
         this.drawAllStrokes(this.tempCtx, "active");
 
-        // Clear tempCanvas and draw the active annotation on it:
-        // this.clearCanvas(this.tempCtx);
-        // this.props.annotationsObject
-        //   .getActiveAnnotation()
-        //   .brushStrokes.forEach((brushstroke) => {
-        //     this.drawPoints(
-        //       brushstroke.coordinates,
-        //       brushstroke.brush,
-        //       false,
-        //       this.tempCtx
-        //     );
-        //   });
-
         // Copy tempCanvas onto interactionCanvas:
         this.clearCanvas(this.interactionCanvas.canvasContext);
         this.interactionCanvas.canvasContext.globalAlpha =

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -235,18 +235,20 @@ export class CanvasClass extends Component<Props, State> {
         .getAllAnnotations()
         .filter(({ toolbox }) => toolbox === Toolboxes.paintbrush)
         .forEach(({ brushStrokes }, annotationIndex) => {
-          brushStrokes.forEach(({ coordinates, brush }) => {
+          brushStrokes.forEach(({ coordinates, spaceTimeInfo, brush }) => {
             coordinates.forEach((point0, i) => {
-              img = drawCapsule(
-                point0,
-                i + 1 < coordinates.length ? coordinates[i + 1] : point0,
-                brush.radius,
-                img,
-                this.props.displayedImage.width,
-                annotationIndex,
-                brush.type,
-                4
-              );
+              if (spaceTimeInfo.z === this.props.sliceIndex) {
+                img = drawCapsule(
+                  point0,
+                  i + 1 < coordinates.length ? coordinates[i + 1] : point0,
+                  brush.radius,
+                  img,
+                  this.props.displayedImage.width,
+                  annotationIndex,
+                  brush.type,
+                  4
+                );
+              }
             });
           });
         });

--- a/src/toolboxes/paintbrush/Store.ts
+++ b/src/toolboxes/paintbrush/Store.ts
@@ -8,14 +8,16 @@ interface PaintbrushData {
   annotationAlpha: number;
   annotationActiveAlpha: number;
   pixelView: boolean;
+  is3D: boolean;
 }
 
 const defaultPaintbrush: PaintbrushData = {
-  pixelView: false,
   brushType: "Paintbrush",
   brushRadius: SLIDER_CONFIG[Sliders.brushRadius].initial,
   annotationAlpha: SLIDER_CONFIG[Sliders.annotationAlpha].initial,
   annotationActiveAlpha: SLIDER_CONFIG[Sliders.annotationActiveAlpha].initial,
+  pixelView: false,
+  is3D: false,
 };
 
 // we've created store with initial value. This can now be used anywhere and will share the value.

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -31,6 +31,7 @@ interface SubmenuProps {
   onClose: (event: MouseEvent) => void;
   openSubmenu: () => void;
   keepSubmenuOpen: boolean;
+  is3D: boolean;
 }
 
 interface Props {
@@ -44,6 +45,7 @@ interface Props {
   onClose: (event: MouseEvent) => void;
   anchorElement: HTMLButtonElement | null;
   isTyping: () => boolean;
+  is3D: boolean;
 }
 
 const useStyles = makeStyles(() =>
@@ -237,36 +239,42 @@ const Submenu = (props: SubmenuProps): ReactElement => {
       icon: icons.brush,
       event: selectBrush,
       active: () => paintbrush.brushType === "Paintbrush",
+      disabled: () => false,
     },
     {
       name: "Eraser",
       icon: icons.eraser,
       event: selectEraser,
       active: () => paintbrush.brushType === "Eraser",
+      disabled: () => false,
     },
     {
       name: "Use 3D brushstokes",
       icon: icons.brush,
       event: toggle3D,
       active: () => paintbrush.is3D,
+      disabled: () => !props.is3D,
     },
     {
       name: "Fill Active Paintbrush",
       icon: icons.fill,
       event: fillBrush,
       active: () => false,
+      disabled: () => false,
     },
     {
       name: "Annotation Transparency",
       icon: icons.annotationTransparency,
       event: toggleShowTransparency,
       active: () => showTransparency,
+      disabled: () => false,
     },
     {
       name: "Show strokes as pixels",
       icon: icons.convert,
       event: togglePixelView,
       active: () => paintbrush.pixelView,
+      disabled: () => false,
     },
   ];
 
@@ -283,7 +291,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
           size="small"
           id="paintbrush-toolbar"
         >
-          {tools.map(({ icon, name, event, active }) => (
+          {tools.map(({ icon, name, event, active, disabled }) => (
             <IconButton
               key={name}
               icon={icon}
@@ -293,6 +301,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
               }}
               onClick={event}
               fill={active()}
+              disabled={disabled()}
             />
           ))}
         </ButtonGroup>
@@ -384,6 +393,7 @@ class Toolbar extends Component<Props> {
         anchorElement={this.props.anchorElement}
         onClose={this.props.onClose}
         keepSubmenuOpen={this.props.keepSubmenuOpen}
+        is3D={this.props.is3D}
       />
     </>
   );

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -165,6 +165,18 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     return true;
   }
 
+  function toggle3D() {
+    setPaintbrush({
+      ...paintbrush,
+      is3D: !paintbrush.is3D,
+    });
+    document.dispatchEvent(
+      new CustomEvent("toggle3D", { detail: Toolboxes.paintbrush })
+    );
+
+    return true;
+  }
+
   function changeAnnotationTransparency(
     _e: ChangeEvent,
     annotationAlpha: number
@@ -192,6 +204,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
       selectBrush,
       selectEraser,
       toggleShowTransparency,
+      toggle3D,
       changeAnnotationTransparency,
       changeAnnotationTransparencyFocused,
     };
@@ -230,6 +243,12 @@ const Submenu = (props: SubmenuProps): ReactElement => {
       icon: icons.eraser,
       event: selectEraser,
       active: () => paintbrush.brushType === "Eraser",
+    },
+    {
+      name: "Use 3D brushstokes",
+      icon: icons.brush,
+      event: toggle3D,
+      active: () => paintbrush.is3D,
     },
     {
       name: "Fill Active Paintbrush",

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -250,7 +250,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     },
     {
       name: "Use 3D brushstokes",
-      icon: icons.brush,
+      icon: icons.brush3D,
       event: toggle3D,
       active: () => paintbrush.is3D,
       disabled: () => !props.is3D,

--- a/src/toolboxes/paintbrush/interfaces.ts
+++ b/src/toolboxes/paintbrush/interfaces.ts
@@ -4,6 +4,7 @@ export interface Brush {
   radius: number;
   type: "paint" | "erase";
   color: string; // rgb(a) string
+  is3D: boolean;
 }
 
 export interface BrushStroke {

--- a/src/toolboxes/paintbrush/interfaces.ts
+++ b/src/toolboxes/paintbrush/interfaces.ts
@@ -1,11 +1,13 @@
 import { XYPoint, ZTPoint } from "@/annotation/interfaces";
 
+export interface Brush {
+  radius: number;
+  type: "paint" | "erase";
+  color: string; // rgb(a) string
+}
+
 export interface BrushStroke {
   coordinates: XYPoint[];
   spaceTimeInfo: ZTPoint;
-  brush: {
-    radius: number;
-    type: "paint" | "erase";
-    color: string; // rgb(a) string
-  };
+  brush: Brush;
 }

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -802,6 +802,7 @@ class UserInterface extends Component<Props, State> {
             keepSubmenuOpen={this.state.keepSubmenuOpen}
             anchorElement={this.state.anchorElement}
             isTyping={this.isTyping}
+            is3D={this.slicesData?.length > 1}
           />
           <SplineToolbar
             buttonClicked={this.state.buttonClicked}


### PR DESCRIPTION
## Description

Adds 3D paintbrush and eraser features. Essentially the `Brush` interface now has an is3D flag (which defaults `false`) but is otherwise stored exactly the same way.

The following works:
- [x] Drawing 3D brushstrokes on canvas
- [x] Adding additional 2D brushstrokes to existing 3D strokes, i.e. for editing a single layer
- [x] Using 2D and 3D eraser strokes with existing paintbrush annotations

The following does not work:
- [ ] Pixel view of 3D strokes, currently will just draw the centre, i.e. as if just a 2D (see #429)
- [ ] TIFF export of 3D strokes, currently will just draw the centre, i.e. as if just a 2D (see #433)

Other fixes made:
- [x] 2D pixel view now obeys the active slice of a 3D image

closes #430 
relates #429 #433
bugs found #426 

## Dependency changes

Has the pipfile.lock or package-lock.json been updated? Yes, as part of `npm i`

## Testing

None

## Documentation

None. @philhallbio will need to make a new issue in DOCUMENT for this.

## Migrations (if applicable)

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
