### PR TITLE
fix: amend 3D 'brushstokes' to 'brushstrokes'

### DIFF
--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -249,7 +249,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
       disabled: () => false,
     },
     {
-      name: "Use 3D brushstokes",
+      name: "Use 3D brushstrokes",
       icon: icons.brush3D,
       event: toggle3D,
       active: () => paintbrush.is3D,


### PR DESCRIPTION
## Description

Use 3D Brushstrokes was named incorrectly, changed from 'brushstokes' to 'brushstrokes'

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
