### PR TITLE
fix: icon highlights

### DIFF
--- a/src/Toolboxes.ts
+++ b/src/Toolboxes.ts
@@ -1,9 +1,11 @@
 import { Tooltip } from "@gliff-ai/style";
 
 export const Toolboxes = {
+  background: "background",
   paintbrush: "paintbrush",
   spline: "spline",
   boundingBox: "boundingBox",
+  ui: "ui",
 } as const;
 
 export type Toolbox = typeof Toolboxes[keyof typeof Toolboxes];

--- a/src/Toolboxes.ts
+++ b/src/Toolboxes.ts
@@ -1,11 +1,9 @@
 import { Tooltip } from "@gliff-ai/style";
 
 export const Toolboxes = {
-  background: "background",
   paintbrush: "paintbrush",
   spline: "spline",
   boundingBox: "boundingBox",
-  ui: "ui",
 } as const;
 
 export type Toolbox = typeof Toolboxes[keyof typeof Toolboxes];

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -42,6 +42,8 @@ export class Annotations {
 
   private redoData: UndoRedo[];
 
+  private redrawUI: () => void;
+
   constructor(data?: Annotation[], audit?: AuditAction[]) {
     this.data = data || [];
     this.audit = audit || [];
@@ -688,6 +690,9 @@ export class Annotations {
   private initUndoRedo = () => {
     this.undoData = [];
     this.redoData = [];
+    if (this.redrawUI !== undefined) {
+      this.redrawUI();
+    }
   };
 
   private updateUndoRedoActions = (method: string, args: unknown): void => {
@@ -698,6 +703,7 @@ export class Annotations {
       },
       redoAction: this.audit[this.audit.length - 1],
     });
+    this.redrawUI();
   };
 
   private applyAction = (
@@ -715,6 +721,7 @@ export class Annotations {
       const undoRedo = this.undoData.pop();
       this.applyAction(undoRedo.undoAction, false);
       this.redoData.push(undoRedo);
+      this.redrawUI();
     }
     return canUndoRedo;
   }
@@ -725,7 +732,14 @@ export class Annotations {
       const undoRedo = this.redoData.pop();
       this.applyAction(undoRedo.redoAction, false);
       this.undoData.push(undoRedo);
+      this.redrawUI();
     }
     return canUndoRedo;
+  }
+
+  giveRedrawCallback(callback: () => void) {
+    // gives the object a callback for redrawing the ANNOTATE UserInterface
+    // this is sometimes needed to update the states of the Undo/Redo buttons
+    this.redrawUI = callback;
   }
 }

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -737,7 +737,7 @@ export class Annotations {
     return canUndoRedo;
   }
 
-  giveRedrawCallback(callback: () => void) {
+  giveRedrawCallback(callback: () => void): void {
     // gives the object a callback for redrawing the ANNOTATE UserInterface
     // this is sometimes needed to update the states of the Undo/Redo buttons
     this.redrawUI = callback;

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -338,7 +338,6 @@ class Toolbar extends Component<Props> {
   };
 
   render = (): ReactElement => {
-    console.log("background", this.props.anchorElement, this.refBackgroundSettingsPopover, this.props.anchorElement === this.refBackgroundSettingsPopover)
     return (
       <>
         <ButtonGroup style={{ all: "revert" }}>

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -337,34 +337,34 @@ class Toolbar extends Component<Props> {
     this.props.handleOpen()(this.refBackgroundSettingsPopover);
   };
 
-  render = (): ReactElement => {
-    return (
-      <>
-        <ButtonGroup style={{ all: "revert" }}>
-          <IconButton
-            tooltip={{
-              name: "Background Settings",
-            }}
-            icon={icons.backgroundSettings}
-            onClick={this.openSubmenu}
-            fill={Boolean(this.props.anchorElement === this.refBackgroundSettingsPopover)}
-            setRefCallback={(ref) => {
-              this.refBackgroundSettingsPopover = ref;
-            }}
-          />
-        </ButtonGroup>
-
-        <Submenu
-          isOpen={
-            Boolean(this.props.anchorElement === this.refBackgroundSettingsPopover)
-          }
-          openSubmenu={this.openSubmenu}
-          anchorElement={this.props.anchorElement}
-          channelControls={this.channelControls}
+  render = (): ReactElement => (
+    <>
+      <ButtonGroup style={{ all: "revert" }}>
+        <IconButton
+          tooltip={{
+            name: "Background Settings",
+          }}
+          icon={icons.backgroundSettings}
+          onClick={this.openSubmenu}
+          fill={Boolean(
+            this.props.anchorElement === this.refBackgroundSettingsPopover
+          )}
+          setRefCallback={(ref) => {
+            this.refBackgroundSettingsPopover = ref;
+          }}
         />
-      </>
-    );
-  }
+      </ButtonGroup>
+
+      <Submenu
+        isOpen={Boolean(
+          this.props.anchorElement === this.refBackgroundSettingsPopover
+        )}
+        openSubmenu={this.openSubmenu}
+        anchorElement={this.props.anchorElement}
+        channelControls={this.channelControls}
+      />
+    </>
+  );
 }
 
 export { Toolbar, ToolboxName };

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -42,7 +42,6 @@ interface SubmenuProps {
 }
 
 interface Props {
-  active: boolean; // toolbox is active
   handleOpen: (
     event?: MouseEvent
   ) => (anchorElement?: HTMLButtonElement) => void;

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -42,8 +42,7 @@ interface SubmenuProps {
 }
 
 interface Props {
-  buttonClicked: string;
-  setButtonClicked: (buttonName: string) => void;
+  active: boolean; // toolbox is active
   handleOpen: (
     event?: MouseEvent
   ) => (anchorElement?: HTMLButtonElement) => void;
@@ -336,36 +335,37 @@ class Toolbar extends Component<Props> {
   openSubmenu = (): void => {
     if (this.props.isTyping()) return;
     this.props.handleOpen()(this.refBackgroundSettingsPopover);
-    this.props.setButtonClicked("Background Settings");
   };
 
-  render = (): ReactElement => (
-    <>
-      <ButtonGroup style={{ all: "revert" }}>
-        <IconButton
-          tooltip={{
-            name: "Background Settings",
-          }}
-          icon={icons.backgroundSettings}
-          onClick={this.openSubmenu}
-          fill={this.props.buttonClicked === "Background Settings"}
-          setRefCallback={(ref) => {
-            this.refBackgroundSettingsPopover = ref;
-          }}
-        />
-      </ButtonGroup>
+  render = (): ReactElement => {
+    console.log("background", this.props.anchorElement, this.refBackgroundSettingsPopover, this.props.anchorElement === this.refBackgroundSettingsPopover)
+    return (
+      <>
+        <ButtonGroup style={{ all: "revert" }}>
+          <IconButton
+            tooltip={{
+              name: "Background Settings",
+            }}
+            icon={icons.backgroundSettings}
+            onClick={this.openSubmenu}
+            fill={Boolean(this.props.anchorElement === this.refBackgroundSettingsPopover)}
+            setRefCallback={(ref) => {
+              this.refBackgroundSettingsPopover = ref;
+            }}
+          />
+        </ButtonGroup>
 
-      <Submenu
-        isOpen={
-          this.props.buttonClicked === "Background Settings" &&
-          Boolean(this.props.anchorElement)
-        }
-        openSubmenu={this.openSubmenu}
-        anchorElement={this.props.anchorElement}
-        channelControls={this.channelControls}
-      />
-    </>
-  );
+        <Submenu
+          isOpen={
+            Boolean(this.props.anchorElement === this.refBackgroundSettingsPopover)
+          }
+          openSubmenu={this.openSubmenu}
+          anchorElement={this.props.anchorElement}
+          channelControls={this.channelControls}
+        />
+      </>
+    );
+  }
 }
 
 export { Toolbar, ToolboxName };

--- a/src/toolboxes/boundingBox/Toolbar.tsx
+++ b/src/toolboxes/boundingBox/Toolbar.tsx
@@ -13,9 +13,11 @@ interface Event extends CustomEvent {
 }
 
 interface Props {
-  buttonClicked: string;
-  setButtonClicked: (buttonName: string) => void;
+  active: boolean; // toolbox is active
   activateToolbox: (activeToolbox: Toolbox) => void;
+  handleOpen: (
+    event?: React.MouseEvent
+  ) => (anchorElement?: HTMLButtonElement) => void;
   isTyping: () => boolean;
 }
 
@@ -40,8 +42,8 @@ class Toolbar extends Component<Props> {
 
   selectBoundingBox = (): void => {
     if (this.props.isTyping()) return;
-    this.props.setButtonClicked("Rectangular Bounding Box");
     this.props.activateToolbox(Toolboxes.boundingBox);
+    this.props.handleOpen()(null); // close whatever submenu is open (boundingBox doesn't have a submenu)
   };
 
   render = (): ReactElement => (
@@ -53,7 +55,7 @@ class Toolbar extends Component<Props> {
             ...getShortcut(`${ToolboxName}.selectBoundingBox`),
           }}
           icon={icons.boundingBox}
-          fill={this.props.buttonClicked === "Rectangular Bounding Box"}
+          fill={this.props.active}
           onClick={this.selectBoundingBox}
         />
       </ButtonGroup>

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -387,35 +387,31 @@ class Toolbar extends Component<Props> {
     this.props.activateToolbox(ToolboxName);
   };
 
-  render = (): ReactElement => {
-    return (
-      <>
-        <ButtonGroup style={{ all: "revert" }}>
-          <IconButton
-            tooltip={{
-              name: "Paintbrush",
-              ...getShortcut("paintbrush.selectBrush"),
-            }}
-            icon={icons.brush}
-            onClick={this.openSubmenu}
-            fill={this.props.active}
-            setRefCallback={(ref: HTMLButtonElement) => {
-              this.refBrushPopover = ref;
-            }}
-          />
-        </ButtonGroup>
-
-        <Submenu
-          isOpen={
-            Boolean(this.props.anchorElement === this.refBrushPopover)
-          }
-          openSubmenu={this.openSubmenu}
-          anchorElement={this.props.anchorElement}
-          is3D={this.props.is3D}
+  render = (): ReactElement => (
+    <>
+      <ButtonGroup style={{ all: "revert" }}>
+        <IconButton
+          tooltip={{
+            name: "Paintbrush",
+            ...getShortcut("paintbrush.selectBrush"),
+          }}
+          icon={icons.brush}
+          onClick={this.openSubmenu}
+          fill={this.props.active}
+          setRefCallback={(ref: HTMLButtonElement) => {
+            this.refBrushPopover = ref;
+          }}
         />
-      </>
-    );
-  }
+      </ButtonGroup>
+
+      <Submenu
+        isOpen={Boolean(this.props.anchorElement === this.refBrushPopover)}
+        openSubmenu={this.openSubmenu}
+        anchorElement={this.props.anchorElement}
+        is3D={this.props.is3D}
+      />
+    </>
+  );
 }
 
 export { Toolbar, ToolboxName };

--- a/src/toolboxes/paintbrush/Toolbar.tsx
+++ b/src/toolboxes/paintbrush/Toolbar.tsx
@@ -33,8 +33,7 @@ interface SubmenuProps {
 }
 
 interface Props {
-  buttonClicked: string;
-  setButtonClicked: (buttonName: string) => void;
+  active: boolean; // toolbox is active
   activateToolbox: (activeToolbox: Toolbox) => void;
   handleOpen: (
     event?: MouseEvent
@@ -385,38 +384,38 @@ class Toolbar extends Component<Props> {
   openSubmenu = (): void => {
     if (this.props.isTyping()) return;
     this.props.handleOpen()(this.refBrushPopover);
-    this.props.setButtonClicked("Paintbrush");
     this.props.activateToolbox(ToolboxName);
   };
 
-  render = (): ReactElement => (
-    <>
-      <ButtonGroup style={{ all: "revert" }}>
-        <IconButton
-          tooltip={{
-            name: "Paintbrush",
-            ...getShortcut("paintbrush.selectBrush"),
-          }}
-          icon={icons.brush}
-          onClick={this.openSubmenu}
-          fill={this.props.buttonClicked === "Paintbrush"}
-          setRefCallback={(ref: HTMLButtonElement) => {
-            this.refBrushPopover = ref;
-          }}
-        />
-      </ButtonGroup>
+  render = (): ReactElement => {
+    return (
+      <>
+        <ButtonGroup style={{ all: "revert" }}>
+          <IconButton
+            tooltip={{
+              name: "Paintbrush",
+              ...getShortcut("paintbrush.selectBrush"),
+            }}
+            icon={icons.brush}
+            onClick={this.openSubmenu}
+            fill={this.props.active}
+            setRefCallback={(ref: HTMLButtonElement) => {
+              this.refBrushPopover = ref;
+            }}
+          />
+        </ButtonGroup>
 
-      <Submenu
-        isOpen={
-          this.props.buttonClicked === "Paintbrush" &&
-          Boolean(this.props.anchorElement)
-        }
-        openSubmenu={this.openSubmenu}
-        anchorElement={this.props.anchorElement}
-        is3D={this.props.is3D}
-      />
-    </>
-  );
+        <Submenu
+          isOpen={
+            Boolean(this.props.anchorElement === this.refBrushPopover)
+          }
+          openSubmenu={this.openSubmenu}
+          anchorElement={this.props.anchorElement}
+          is3D={this.props.is3D}
+        />
+      </>
+    );
+  }
 }
 
 export { Toolbar, ToolboxName };

--- a/src/toolboxes/spline/Toolbar.tsx
+++ b/src/toolboxes/spline/Toolbar.tsx
@@ -201,9 +201,7 @@ class Toolbar extends Component<Props> {
       </ButtonGroup>
 
       <Submenu
-        isOpen={
-          Boolean(this.props.anchorElement === this.refSplinePopover)
-        }
+        isOpen={Boolean(this.props.anchorElement === this.refSplinePopover)}
         anchorElement={this.props.anchorElement}
         openSubmenu={this.openSubmenu}
       />

--- a/src/toolboxes/spline/Toolbar.tsx
+++ b/src/toolboxes/spline/Toolbar.tsx
@@ -154,13 +154,13 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     </Popper>
   );
 };
+
 interface Event extends CustomEvent {
   type: typeof events[number];
 }
 
 interface Props {
-  buttonClicked: string;
-  setButtonClicked: (buttonName: string) => void;
+  active: boolean; // toolbox is active
   activateToolbox: (activeToolbox: Toolbox) => void;
   handleOpen: (
     event?: MouseEvent
@@ -180,7 +180,6 @@ class Toolbar extends Component<Props> {
   openSubmenu = (): void => {
     if (this.props.isTyping()) return;
     this.props.handleOpen()(this.refSplinePopover);
-    this.props.setButtonClicked("Spline");
     this.props.activateToolbox(ToolboxName);
   };
 
@@ -194,7 +193,7 @@ class Toolbar extends Component<Props> {
           }}
           icon={icons.spline}
           onClick={this.openSubmenu}
-          fill={this.props.buttonClicked === "Spline"}
+          fill={this.props.active}
           setRefCallback={(ref: HTMLButtonElement) => {
             this.refSplinePopover = ref;
           }}
@@ -203,8 +202,7 @@ class Toolbar extends Component<Props> {
 
       <Submenu
         isOpen={
-          this.props.buttonClicked === "Spline" &&
-          Boolean(this.props.anchorElement)
+          Boolean(this.props.anchorElement === this.refSplinePopover)
         }
         anchorElement={this.props.anchorElement}
         openSubmenu={this.openSubmenu}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -720,7 +720,7 @@ class UserInterface extends Component<Props, State> {
         name: "Select Annotation",
         icon: icons.select,
         event: "toggleMode",
-        active: () => this.state.buttonClicked === "Select",
+        active: () => this.state.mode === Mode.select,
         enabled: () => true,
       },
       {

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -85,7 +85,7 @@ interface State {
   redraw: number;
   sliceIndex: number;
   channels: boolean[];
-  anchorElement: HTMLButtonElement | null; // A HTML element. It's used to set the position of the popover menu https://material-ui.com/api/menu/#props
+  anchorElement: HTMLButtonElement | null; // A HTML element. It specifies which button has its submenu open, and serves as anchorEl for that submenu: https://material-ui.com/api/menu/#props
   buttonClicked: string;
   mode: Mode;
   canvasContainerColour: number[];

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -195,7 +195,10 @@ class UserInterface extends Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
+
     this.annotationsObject = this.props.annotationsObject || new Annotations();
+    this.annotationsObject.giveRedrawCallback(this.callRedraw)
+
     this.slicesData = this.props.slicesData || null;
 
     this.state = {
@@ -749,14 +752,14 @@ class UserInterface extends Component<Props, State> {
         icon: icons.undo,
         event: "undo",
         active: () => false,
-        enabled: () => this.state.buttonClicked === "Undo last action",
+        enabled: () => this.annotationsObject.canUndo(),
       },
       {
         name: "Redo last action",
         icon: icons.redo,
         event: "redo",
         active: () => false,
-        enabled: () => this.state.buttonClicked === "Redo last action",
+        enabled: () => this.annotationsObject.canRedo(),
       },
     ] as const;
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -197,7 +197,7 @@ class UserInterface extends Component<Props, State> {
     super(props);
 
     this.annotationsObject = this.props.annotationsObject || new Annotations();
-    this.annotationsObject.giveRedrawCallback(this.callRedraw)
+    this.annotationsObject.giveRedrawCallback(this.callRedraw);
 
     this.slicesData = this.props.slicesData || null;
 
@@ -744,7 +744,8 @@ class UserInterface extends Component<Props, State> {
         name: "Annotation Label",
         icon: icons.annotationLabel,
         event: "selectAnnotationLabel",
-        active: () => this.state.anchorElement === this.refBtnsPopovers["Annotation Label"],
+        active: () =>
+          this.state.anchorElement === this.refBtnsPopovers["Annotation Label"],
         enabled: () => true,
       },
       {
@@ -834,7 +835,8 @@ class UserInterface extends Component<Props, State> {
 
         <LabelsSubmenu
           isOpen={
-            this.state.anchorElement === this.refBtnsPopovers["Annotation Label"]
+            this.state.anchorElement ===
+            this.refBtnsPopovers["Annotation Label"]
           }
           anchorElement={this.state.anchorElement}
           onClose={this.handleClose}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -85,7 +85,7 @@ interface State {
   redraw: number;
   sliceIndex: number;
   channels: boolean[];
-  anchorElement: HTMLButtonElement | null; // A HTML element. It specifies which button has its submenu open, and serves as anchorEl for that submenu: https://material-ui.com/api/menu/#props
+  activeSubmenuAnchor: HTMLButtonElement | null; // A HTML element. It specifies which button has its submenu open, and serves as anchorEl for that submenu: https://material-ui.com/api/menu/#props
   buttonClicked: string;
   mode: Mode;
   canvasContainerColour: number[];
@@ -212,7 +212,7 @@ class UserInterface extends Component<Props, State> {
       channels: [true],
       displayedImage: this.slicesData ? this.slicesData[0][0] : null,
       redraw: 0,
-      anchorElement: null,
+      activeSubmenuAnchor: null,
       buttonClicked: null,
       activeToolbox: Toolboxes.paintbrush,
       mode: Mode.draw,
@@ -593,17 +593,17 @@ class UserInterface extends Component<Props, State> {
   };
 
   handleClose = (): void => {
-    this.setState({ anchorElement: null });
+    this.setState({ activeSubmenuAnchor: null });
   };
 
   handleOpen =
     (event?: React.MouseEvent) =>
-    (anchorElement?: HTMLButtonElement): void => {
-      if (anchorElement !== undefined) {
-        this.setState({ anchorElement });
+    (activeSubmenuAnchor?: HTMLButtonElement): void => {
+      if (activeSubmenuAnchor !== undefined) {
+        this.setState({ activeSubmenuAnchor });
       } else if (event) {
         this.setState({
-          anchorElement: event.currentTarget as HTMLButtonElement,
+          activeSubmenuAnchor: event.currentTarget as HTMLButtonElement,
         });
       }
     };
@@ -656,7 +656,7 @@ class UserInterface extends Component<Props, State> {
   isTyping = (): boolean =>
     // Added to prevent single-key shortcuts that are also valid text input
     // to get triggered during text input.
-    this.refBtnsPopovers.Labels === this.state.anchorElement;
+    this.refBtnsPopovers.Labels === this.state.activeSubmenuAnchor;
 
   render = (): ReactNode => {
     const { classes, showAppBar, saveAnnotationsCallback } = this.props;
@@ -743,7 +743,8 @@ class UserInterface extends Component<Props, State> {
         icon: icons.annotationLabel,
         event: "selectAnnotationLabel",
         active: () =>
-          this.state.anchorElement === this.refBtnsPopovers["Annotation Label"],
+          this.state.activeSubmenuAnchor ===
+          this.refBtnsPopovers["Annotation Label"],
         enabled: () => true,
       },
       {
@@ -802,7 +803,7 @@ class UserInterface extends Component<Props, State> {
             active={this.state.activeToolbox === "paintbrush"}
             activateToolbox={this.activateToolbox}
             handleOpen={this.handleOpen}
-            anchorElement={this.state.anchorElement}
+            anchorElement={this.state.activeSubmenuAnchor}
             isTyping={this.isTyping}
             is3D={this.slicesData?.length > 1}
           />
@@ -810,7 +811,7 @@ class UserInterface extends Component<Props, State> {
             active={this.state.activeToolbox === "spline"}
             activateToolbox={this.activateToolbox}
             handleOpen={this.handleOpen}
-            anchorElement={this.state.anchorElement}
+            anchorElement={this.state.activeSubmenuAnchor}
             isTyping={this.isTyping}
           />
 
@@ -822,7 +823,7 @@ class UserInterface extends Component<Props, State> {
           />
           <BackgroundToolbar
             handleOpen={this.handleOpen}
-            anchorElement={this.state.anchorElement}
+            anchorElement={this.state.activeSubmenuAnchor}
             isTyping={this.isTyping}
             channels={this.state.channels}
             toggleChannelAtIndex={this.toggleChannelAtIndex}
@@ -832,10 +833,10 @@ class UserInterface extends Component<Props, State> {
 
         <LabelsSubmenu
           isOpen={
-            this.state.anchorElement ===
+            this.state.activeSubmenuAnchor ===
             this.refBtnsPopovers["Annotation Label"]
           }
-          anchorElement={this.state.anchorElement}
+          anchorElement={this.state.activeSubmenuAnchor}
           onClose={this.handleClose}
           annotationsObject={this.annotationsObject}
           presetLabels={this.presetLabels}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -823,7 +823,6 @@ class UserInterface extends Component<Props, State> {
             isTyping={this.isTyping}
           />
           <BackgroundToolbar
-            active={this.state.activeToolbox === "background"}
             handleOpen={this.handleOpen}
             anchorElement={this.state.anchorElement}
             isTyping={this.isTyping}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -598,7 +598,7 @@ class UserInterface extends Component<Props, State> {
   handleOpen =
     (event?: React.MouseEvent) =>
     (anchorElement?: HTMLButtonElement): void => {
-      if (anchorElement) {
+      if (anchorElement !== undefined) {
         this.setState({ anchorElement });
       } else if (event) {
         this.setState({
@@ -797,8 +797,7 @@ class UserInterface extends Component<Props, State> {
         </ButtonGroup>
         <ButtonGroup>
           <PaintbrushToolbar
-            buttonClicked={this.state.buttonClicked}
-            setButtonClicked={this.setButtonClicked}
+            active={this.state.activeToolbox === "paintbrush"}
             activateToolbox={this.activateToolbox}
             handleOpen={this.handleOpen}
             anchorElement={this.state.anchorElement}
@@ -806,8 +805,7 @@ class UserInterface extends Component<Props, State> {
             is3D={this.slicesData?.length > 1}
           />
           <SplineToolbar
-            buttonClicked={this.state.buttonClicked}
-            setButtonClicked={this.setButtonClicked}
+            active={this.state.activeToolbox === "spline"}
             activateToolbox={this.activateToolbox}
             handleOpen={this.handleOpen}
             anchorElement={this.state.anchorElement}
@@ -815,14 +813,13 @@ class UserInterface extends Component<Props, State> {
           />
 
           <BoundingBoxToolbar
-            buttonClicked={this.state.buttonClicked}
-            setButtonClicked={this.setButtonClicked}
+            active={this.state.activeToolbox === "boundingBox"}
             activateToolbox={this.activateToolbox}
+            handleOpen={this.handleOpen}
             isTyping={this.isTyping}
           />
           <BackgroundToolbar
-            buttonClicked={this.state.buttonClicked}
-            setButtonClicked={this.setButtonClicked}
+            active={this.state.activeToolbox === "background"}
             handleOpen={this.handleOpen}
             anchorElement={this.state.anchorElement}
             isTyping={this.isTyping}

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -744,7 +744,7 @@ class UserInterface extends Component<Props, State> {
         name: "Annotation Label",
         icon: icons.annotationLabel,
         event: "selectAnnotationLabel",
-        active: () => this.state.buttonClicked === "Annotation Label",
+        active: () => this.state.anchorElement === this.refBtnsPopovers["Annotation Label"],
         enabled: () => true,
       },
       {
@@ -834,8 +834,7 @@ class UserInterface extends Component<Props, State> {
 
         <LabelsSubmenu
           isOpen={
-            this.state.buttonClicked === "Annotation Label" &&
-            Boolean(this.state.anchorElement)
+            this.state.anchorElement === this.refBtnsPopovers["Annotation Label"]
           }
           anchorElement={this.state.anchorElement}
           onClose={this.handleClose}


### PR DESCRIPTION
## Description

Fixes the green button highlights to work in a sensible and consistent way:

- The Paintbrush, Spline and Bounding Box buttons are highlighted if and only if the corresponding toolbox is active
- the `activeToolbox` state is now only used to specify which of Paintbrush, Spline and Bounding Box are active, this means you can have the Background toolbar open and still have Paintbrush activated and be able to draw.
- the `anchorElement` state is now used in a simpler way - it specifies which button's submenu is open, while also serving as the `anchorEl` prop for that submenu. It was kind of like this before but more explicitly so now I think. So the roles of `activeToolbox` and `anchorElement` are more clearly separated now; the former specifies which of the three annotation toolboxes is active, the latter says which submenu is open.
- `buttonClicked` is used a lot less - only for highlighting the submenu options in the Background toolbar now. It seems like the old behaviour was to remember the most recently clicked button so it can be highlighted, which seems confusing from a UX perspective because we also use highlights to indicate something is active, which seems more intuitive to me. If we do want that behaviour then let me know and I'll find some way to make it consistent, otherwise I'll gladly strip it out completely.

Also fixes the undo/redo buttons being constantly disabled.

closes #282 #460 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
