### PR TITLE
fix: this.redrawUI is not a function

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -703,7 +703,9 @@ export class Annotations {
       },
       redoAction: this.audit[this.audit.length - 1],
     });
-    this.redrawUI();
+    if (this.redrawUI !== undefined) {
+      this.redrawUI();
+    }
   };
 
   private applyAction = (
@@ -721,7 +723,9 @@ export class Annotations {
       const undoRedo = this.undoData.pop();
       this.applyAction(undoRedo.undoAction, false);
       this.redoData.push(undoRedo);
-      this.redrawUI();
+      if (this.redrawUI !== undefined) {
+        this.redrawUI();
+      }
     }
     return canUndoRedo;
   }
@@ -732,7 +736,9 @@ export class Annotations {
       const undoRedo = this.redoData.pop();
       this.applyAction(undoRedo.redoAction, false);
       this.undoData.push(undoRedo);
-      this.redrawUI();
+      if (this.redrawUI !== undefined) {
+        this.redrawUI();
+      }
     }
     return canUndoRedo;
   }

--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -690,9 +690,7 @@ export class Annotations {
   private initUndoRedo = () => {
     this.undoData = [];
     this.redoData = [];
-    if (this.redrawUI !== undefined) {
-      this.redrawUI();
-    }
+    this.redrawUI?.();
   };
 
   private updateUndoRedoActions = (method: string, args: unknown): void => {
@@ -703,9 +701,7 @@ export class Annotations {
       },
       redoAction: this.audit[this.audit.length - 1],
     });
-    if (this.redrawUI !== undefined) {
-      this.redrawUI();
-    }
+    this.redrawUI?.();
   };
 
   private applyAction = (
@@ -723,9 +719,7 @@ export class Annotations {
       const undoRedo = this.undoData.pop();
       this.applyAction(undoRedo.undoAction, false);
       this.redoData.push(undoRedo);
-      if (this.redrawUI !== undefined) {
-        this.redrawUI();
-      }
+      this.redrawUI?.();
     }
     return canUndoRedo;
   }
@@ -736,9 +730,7 @@ export class Annotations {
       const undoRedo = this.redoData.pop();
       this.applyAction(undoRedo.redoAction, false);
       this.undoData.push(undoRedo);
-      if (this.redrawUI !== undefined) {
-        this.redrawUI();
-      }
+      this.redrawUI?.();
     }
     return canUndoRedo;
   }

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -498,7 +498,7 @@ export class CanvasClass extends Component<Props, State> {
   };
 
   onMouseUp = (canvasX: number, canvasY: number): void => {
-    if (this.props.mode === Mode.draw) {
+    if (this.props.mode === Mode.draw && this.isDrawing) {
       // End painting & save painting
 
       // Draw to this end pos

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -254,6 +254,7 @@ class UserInterface extends Component<Props, State> {
       prevProps.annotationsObject !== this.props.annotationsObject
     ) {
       this.annotationsObject = this.props.annotationsObject;
+      this.annotationsObject.giveRedrawCallback(this.callRedraw);
       this.callRedraw();
     }
   };
@@ -457,6 +458,7 @@ class UserInterface extends Component<Props, State> {
     // Otherwise the props for annotationsObject will update after the uplaoed image has been stored.
     if (!this.props.annotationsObject) {
       this.annotationsObject = new Annotations();
+      this.annotationsObject.giveRedrawCallback(this.callRedraw);
       this.annotationsObject.addAnnotation(this.state.activeToolbox);
     }
 


### PR DESCRIPTION
## Description

Fixes the `this.redrawUI is not a function` errors we had today. Seems the bug was also causing us to hit a react error boundary on Ctrl-Arrow; that's also fixed now.

While I was there, I found a bug in click-select where paint would be drawn on mouseUp if you selected a brushstroke, so I fixed that too.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
