### PR TITLE
feat: Access for members

### DIFF
--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,3 +1,4 @@
+import { UserAccess } from "@/ui";
 import ReactDOM from "react-dom";
 import { UserInterface } from "../src";
 import loadImage from "./autoload";
@@ -8,7 +9,7 @@ loadImage("./zebrafish-heart.jpg").then(
       <UserInterface
         slicesData={slicesData}
         imageFileInfo={imageFileInfo}
-        isUserOwner={true}
+        userAccess={UserAccess.Owner}
       />,
       document.getElementById("react-container")
     );

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -52,6 +52,12 @@ interface Event extends CustomEvent {
   type: typeof events[number];
 }
 
+export enum UserAccess {
+  Owner = "owner",
+  Member = "member",
+  Collaborator = "collaborator",
+}
+
 // Here we define the methods that are exposed to be called by keyboard shortcuts
 export const events = [
   "nextAnnotation",
@@ -172,14 +178,14 @@ interface Props extends WithStyles<typeof styles> {
   showAppBar?: boolean;
   setIsLoading?: (isLoading: boolean) => void;
   trustedServiceButtonToolbar?: ReactElement | null;
-  isUserOwner?: boolean;
+  userAccess?: UserAccess;
 }
 
 class UserInterface extends Component<Props, State> {
   static defaultProps = {
     showAppBar: true,
     trustedServiceButtonToolbar: null,
-    isUserOwner: false,
+    userAccess: UserAccess.Collaborator,
   } as Pick<Props, "showAppBar">;
 
   annotationsObject: Annotations;
@@ -442,7 +448,7 @@ class UserInterface extends Component<Props, State> {
     imageFileInfo: ImageFileInfo[],
     slicesData: ImageBitmap[][][]
   ): void => {
-    if (!this.props.isUserOwner) return;
+    if (this.props.userAccess === UserAccess.Collaborator) return;
 
     [this.imageFileInfo] = imageFileInfo; // the Upload component passes arrays of images/metadata even when multiple=false, as it is in ANNOTATE but not CURATE
     [this.slicesData] = slicesData;
@@ -662,7 +668,8 @@ class UserInterface extends Component<Props, State> {
 
     const uploadDownload = (
       <>
-        {this.props.isUserOwner && (
+        {(this.props.userAccess === UserAccess.Owner ||
+          this.props.userAccess === UserAccess.Member) && (
           <Grid item>
             <UploadImage
               setUploadedImage={this.setUploadedImage}


### PR DESCRIPTION
## Description
Add access for team members: the `userAccess` prop replaces `isOwner`.

## Dependency changes
No

## Testing
No

## Documentation
No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
