### PR TITLE
fix: eraser disappearing

### DIFF
--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -302,7 +302,7 @@ export class CanvasClass extends Component<Props, State> {
         .getAllAnnotations()
         .forEach((annotation, i) => {
           if (
-            annotation.toolbox === Toolboxes.paintbrush && 
+            annotation.toolbox === Toolboxes.paintbrush &&
             !(i === activeAnnotationID && drawWhich === "inactive") &&
             !(i !== activeAnnotationID && drawWhich === "active")
           ) {

--- a/src/toolboxes/paintbrush/Canvas.tsx
+++ b/src/toolboxes/paintbrush/Canvas.tsx
@@ -302,8 +302,9 @@ export class CanvasClass extends Component<Props, State> {
         .getAllAnnotations()
         .forEach((annotation, i) => {
           if (
-            annotation.toolbox === Toolboxes.paintbrush &&
-            !(i === activeAnnotationID && drawWhich === "inactive")
+            annotation.toolbox === Toolboxes.paintbrush && 
+            !(i === activeAnnotationID && drawWhich === "inactive") &&
+            !(i !== activeAnnotationID && drawWhich === "active")
           ) {
             this.clearCanvas(this.tempCtx);
             annotation.brushStrokes.forEach((brushStrokes) => {
@@ -444,15 +445,7 @@ export class CanvasClass extends Component<Props, State> {
         this.drawAllStrokes(this.backgroundCanvas?.canvasContext, "inactive");
 
         // Redraw the active annotation:
-        this.drawAllStrokes(this.tempCtx, "active");
-
-        // Copy tempCanvas onto interactionCanvas:
-        this.clearCanvas(this.interactionCanvas.canvasContext);
-        this.interactionCanvas.canvasContext.globalAlpha =
-          this.props.annotationActiveAlpha;
-        this.interactionCanvas.canvasContext.globalCompositeOperation =
-          "source-over";
-        this.interactionCanvas.canvasContext.drawImage(this.tempCanvas, 0, 0);
+        this.drawAllStrokes(this.interactionCanvas.canvasContext, "active");
       }
 
       // Ensure the initial down position gets added to our line


### PR DESCRIPTION
## Description

Found a rendering bug while making the `Annotations` unit tests. To reproduce, make two or more brush annotations, activate any but the last, and use the eraser on it. The active annotation will disappear while the last one gets brighter. This was being caused by `drawWhich === "active"` not being listened for in `drawAllStrokes`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] If appropriate, I have bumped any version numbers
