### PR TITLE
fix: disappearing annotations

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -86,7 +86,7 @@ export class Annotations {
   @log
   deleteActiveAnnotation(): void {
     this.data.splice(this.activeAnnotationID, 1);
-    if (this.activeAnnotationID >= this.data.length) {
+    if (this.activeAnnotationID >= this.data.length && this.data.length > 0) {
       this.activeAnnotationID = this.data.length - 1; // necessary if we delete the one on the end
     }
     if (this.data.length === 0) {

--- a/src/toolboxes/boundingBox/Toolbar.tsx
+++ b/src/toolboxes/boundingBox/Toolbar.tsx
@@ -35,7 +35,7 @@ class Toolbar extends Component<Props> {
   }
 
   handleEvent = (event: Event): void => {
-    if (event.detail === "Rectangular Bounding Box") {
+    if (event.detail === Toolboxes.boundingBox) {
       this[event.type]?.call(this);
     }
   };

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -568,8 +568,9 @@ class UserInterface extends Component<Props, State> {
   };
 
   clearActiveAnnotation = (): void => {
+    const deletedLastAnnotation = this.annotationsObject.length() === 1;
     this.annotationsObject.deleteActiveAnnotation();
-    if (this.annotationsObject.length() === 1) {
+    if (deletedLastAnnotation) {
       // if we delete the last annotation, annotationsObject will make a new one with the paintbrush toolbox
       // (since it doesn't know which tool is active), so we set the toolbox correctly here:
       this.annotationsObject.setActiveAnnotationToolbox(


### PR DESCRIPTION
## Description

Fixes a bug where deleting the second annotation causes the first to disappear when they're different toolboxes.

Also fixes a bug where `activeAnnotationID` was getting set to `-1` when deleting the final annotation - not sure if it was causing any problems in practice but it's not meant to happen.

Also fixes the Bounding Box shortcut.

closes #509


- [ ] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
