### PR TITLE
fix: listing 3D image slices as separate channels

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -455,7 +455,7 @@ class UserInterface extends Component<Props, State> {
     this.setState(
       {
         sliceIndex: 0,
-        channels: Array(slicesData[0].length).fill(true) as boolean[],
+        channels: Array(this.slicesData[0].length).fill(true) as boolean[],
       },
       this.mixChannels
     );


### PR DESCRIPTION
## Description

Fixes a bug where ANNOTATE would list 3D image slices as separate channels in the channel picker. 

closes #427 

- [x] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have performed a self-review of my own code.
- [x] I have assigned **3 or less** reviewers.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
