### PR TITLE
fix: hack in support for makeStyles in package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/plugin-transform-runtime": "^7.16.4",
         "@gliff-ai/slpf": "^1.1.2",
-        "@gliff-ai/style": "^8.0.0",
+        "@gliff-ai/style": "^8.1.4",
         "@gliff-ai/upload": "^1.0.1",
         "@percy/selenium-webdriver": "^1.0.0",
         "@types/selenium-webdriver": "^4.0.16",
@@ -2025,9 +2025,9 @@
       "integrity": "sha512-PsCPLF6s66nY56Gr/W+bRTM85wJ/IDdXYU2D7c4bnsQ9dzqWDDuoDx6m9wrJjmr6kxtQxMnfHr915tl8lTA5mw=="
     },
     "node_modules/@gliff-ai/style": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-8.0.0.tgz",
-      "integrity": "sha512-FpIpfYhtd5JF02bL1TnX6bh83qZRQglQ7hFGuvAY6nyavdHyWBzj066FSER+59qsn4V2kjaD08b+3MahERtVtg==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-8.1.4.tgz",
+      "integrity": "sha512-3AJJUFc45AStYivgVZ7VPaSSgJG0/T46PVqIfQRhlBqZ1RWPNetI2iUQv3BmdXKCuu9+tkiux8jv891XIccR+A==",
       "dependencies": {
         "react-inlinesvg": "^2.3.0"
       },
@@ -13877,9 +13877,9 @@
       "integrity": "sha512-PsCPLF6s66nY56Gr/W+bRTM85wJ/IDdXYU2D7c4bnsQ9dzqWDDuoDx6m9wrJjmr6kxtQxMnfHr915tl8lTA5mw=="
     },
     "@gliff-ai/style": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-8.0.0.tgz",
-      "integrity": "sha512-FpIpfYhtd5JF02bL1TnX6bh83qZRQglQ7hFGuvAY6nyavdHyWBzj066FSER+59qsn4V2kjaD08b+3MahERtVtg==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-8.1.4.tgz",
+      "integrity": "sha512-3AJJUFc45AStYivgVZ7VPaSSgJG0/T46PVqIfQRhlBqZ1RWPNetI2iUQv3BmdXKCuu9+tkiux8jv891XIccR+A==",
       "requires": {
         "react-inlinesvg": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "npx --no-install vite build -c vite.config.lib.ts && tsc --emitDeclarationOnly --outDir dist && tsc-alias -p tsconfig.json",
+    "build": "npx vite build -c vite.config.lib.ts && tsc --emitDeclarationOnly --outDir dist && tsc-alias -p tsconfig.json && npm run build:patch",
     "watch": "npx --no-install vite build -c vite.config.lib.ts --watch",
     "format": "npx --no-install prettier --write src",
     "prettier": "npx --no-install prettier -c src",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "serve": "vite",
     "build:example": "vite build",
     "test": "jest --coverage --passWithNoTests",
+    "build:patch": "sed -i 's/const generateClassName$1 = createGenerateClassName();/const generateClassName$1 = createGenerateClassName({seed:\"\",disableGlobal:true,productionPrefix:\"jss-annotate-\"});/g' dist/index.es.js",
     "test:visual": "npx percy snapshot snapshots.yml",
     "test:e2e": "percy exec -- jest -c jest.e2e.config.js --no-colors",
     "dev": "vite --host"
@@ -30,7 +31,7 @@
     "@emotion/styled": "^11.6.0",
     "@gliff-ai/eslint-config": "^0.1.3",
     "@gliff-ai/jest-browserstack-automate": "^5.0.6",
-    "@gliff-ai/style": "^8.0.0",
+    "@gliff-ai/style": "^8.1.4",
     "@mui/icons-material": "^5.2.5",
     "@mui/lab": "^5.0.0-alpha.64",
     "@mui/material": "^5.2.8",
@@ -60,7 +61,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
-    "@gliff-ai/style": "^8.0.0",
+    "@gliff-ai/style": "^8.1.4",
     "@mui/icons-material": "^5.2.5",
     "@mui/lab": "^5.0.0-alpha.64",
     "@mui/material": "^5.2.8",

--- a/vite.config.lib.ts
+++ b/vite.config.lib.ts
@@ -20,7 +20,10 @@ export default defineConfig({
         "react-router-dom",
         "@mui/material",
         "@mui/icons-material",
-        "@mui/lab",
+        "@mui/styles",
+        "@mui/system",
+        "@emotion/react",
+        "@emotion/styled",
         "@gliff-ai/style",
       ],
       output: {


### PR DESCRIPTION
## Description

As a temp fix to allow us to to use makeStyles in parent repos, hardcode the CSS prefix to "annotate" rather than the generic JSS.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
