### PR TITLE
fix: explicitly allow null coords in BoundingBox interface

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,3 +2,5 @@ export { Annotations } from "@/annotation";
 export type { Annotation, AuditAction } from "@/annotation/interfaces";
 export { getTiffData } from "@/download/DownloadAsTiff";
 export { UserInterface } from "./ui";
+export type { Spline } from "@/toolboxes/spline";
+export type { BoundingBox } from "@/toolboxes/boundingBox";

--- a/src/toolboxes/boundingBox/interfaces.ts
+++ b/src/toolboxes/boundingBox/interfaces.ts
@@ -1,8 +1,8 @@
 import { XYPoint, ZTPoint } from "@/annotation/interfaces";
 
 export interface BoundingBoxCoordinates {
-  topLeft: XYPoint;
-  bottomRight: XYPoint;
+  topLeft: XYPoint | { x: null; y: null };
+  bottomRight: XYPoint | { x: null; y: null };
 }
 
 export interface BoundingBox {


### PR DESCRIPTION
## Description

This was necessary for the `makeAnnotationsJson` unit test in DOMINATE, because it turns out the `Annotation` interface doesn't actually allow for `null` coordinates for bounding boxes (which is currently how "no bounding box" is represented) when `strictNullChecks` is enabled. We have `strictNullChecks` set in DOMINATE but not in ANNOTATE, which is why this didn't cause a problem there.

Also exported the `Spline` and `BoundingBox` interfaces so I don't have to duplicate them in the unit test.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
