### PR TITLE
fix: pick fill brush coord simplification tolerance more cleverly

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -533,9 +533,12 @@ export class Annotations {
     // Simplifying the line for computational efficiency
     const strokeCoordinates = this.getBrushStrokeCoordinates();
 
-    // simplify
-    // TODO pick tolerance more cleverly
-    const simplifiedCoordinates = simplify(strokeCoordinates, 10, true);
+    // simplify coordinates:
+    const simplifiedCoordinates = simplify(
+      strokeCoordinates,
+      this.data[this.activeAnnotationID].brushStrokes[0].brush.radius,
+      true
+    );
 
     const linesToFill: XYPoint[][] = slpfLines(simplifiedCoordinates);
 


### PR DESCRIPTION
## Description

Sets the brushstroke coordinate simplification tolerance to the brush radius when running `fillBrush`, preventing gaps at the border when brush radius is small.

closes #452 

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
