### PR TITLE
fix: spline stickiness

### DIFF
--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -304,7 +304,7 @@ class CanvasClass extends Component<Props, State> {
       if (
         !(
           this.selectedPointIndex === coordinates.length - 1 &&
-          this.dragPoint != coordinates[coordinates.length - 1]
+          this.dragPoint !== coordinates[coordinates.length - 1]
         )
       )
         // But if the selected point is the last point in the spline, and we've not actually moved it,
@@ -343,22 +343,20 @@ class CanvasClass extends Component<Props, State> {
     if (this.sliceIndexMatch()) {
       if (isCTRL) {
         this.onCTRLClick(x, y);
-      } else {
-        if (
-          this.props.mode === Mode.draw &&
-          !this.props.annotationsObject.splineIsClosed() &&
-          this.props.activeToolbox === "Spline" &&
-          JSON.stringify({ x: imageX, y: imageY }) !==
-            JSON.stringify(coordinates[coordinates.length - 1]) // don't allow duplicate points
-        ) {
-          // if a normal spline, just add points as needed
-          this.props.annotationsObject.addSplinePoint({
-            x: imageX,
-            y: imageY,
-          });
-          this.selectedPointIndex =
-            this.props.annotationsObject.getSplineLength() - 1;
-        }
+      } else if (
+        this.props.mode === Mode.draw &&
+        !this.props.annotationsObject.splineIsClosed() &&
+        this.props.activeToolbox === "Spline" &&
+        JSON.stringify({ x: imageX, y: imageY }) !==
+          JSON.stringify(coordinates[coordinates.length - 1]) // don't allow duplicate points
+      ) {
+        // if a normal spline, just add points as needed
+        this.props.annotationsObject.addSplinePoint({
+          x: imageX,
+          y: imageY,
+        });
+        this.selectedPointIndex =
+          this.props.annotationsObject.getSplineLength() - 1;
       }
     }
 

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -346,24 +346,18 @@ class CanvasClass extends Component<Props, State> {
       } else {
         if (
           this.props.mode === Mode.draw &&
-          !this.props.annotationsObject.splineIsClosed()
+          !this.props.annotationsObject.splineIsClosed() &&
+          this.props.activeToolbox === "Spline" &&
+          JSON.stringify({ x: imageX, y: imageY }) !==
+            JSON.stringify(coordinates[coordinates.length - 1]) // don't allow duplicate points
         ) {
-          // else, i.e. not near an existing point
-          // if the spline is not closed and we are in Mode.draw then
-          // add coordinates to the current spline
-          if (
-            this.props.activeToolbox === "Spline" &&
-            JSON.stringify({ x: imageX, y: imageY }) !==
-              JSON.stringify(coordinates[coordinates.length - 1]) // don't allow duplicate points
-          ) {
-            // if a normal spline, just add points as needed
-            this.props.annotationsObject.addSplinePoint({
-              x: imageX,
-              y: imageY,
-            });
-            this.selectedPointIndex =
-              this.props.annotationsObject.getSplineLength() - 1;
-          }
+          // if a normal spline, just add points as needed
+          this.props.annotationsObject.addSplinePoint({
+            x: imageX,
+            y: imageY,
+          });
+          this.selectedPointIndex =
+            this.props.annotationsObject.getSplineLength() - 1;
         }
       }
     }

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -351,7 +351,11 @@ class CanvasClass extends Component<Props, State> {
           // else, i.e. not near an existing point
           // if the spline is not closed and we are in Mode.draw then
           // add coordinates to the current spline
-          if (this.props.activeToolbox === "Spline") {
+          if (
+            this.props.activeToolbox === "Spline" &&
+            JSON.stringify({ x: imageX, y: imageY }) !==
+              JSON.stringify(coordinates[coordinates.length - 1]) // don't allow duplicate points
+          ) {
             // if a normal spline, just add points as needed
             this.props.annotationsObject.addSplinePoint({
               x: imageX,

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -328,26 +328,7 @@ class CanvasClass extends Component<Props, State> {
       if (isCTRL) {
         this.onCTRLClick(x, y);
       } else {
-        // if our current spline annotation object is for the visible slice
-        // get the current spline coordinates
-        const coordinates = this.props.annotationsObject.getSplineCoordinates();
-
-        // check if we clicked within the nudge radius of an existing point
-        const nudgePointIdx = this.clickNearPoint(
-          { x: imageX, y: imageY },
-          coordinates
-        );
-
-        if (nudgePointIdx !== -1) {
-          // If the mouse click was near an existing point, nudge that point
-          const nudgePoint = coordinates[nudgePointIdx];
-
-          this.props.annotationsObject.updateSplinePoint(
-            (nudgePoint.x + imageX) / 2,
-            (nudgePoint.y + imageY) / 2,
-            nudgePointIdx
-          );
-        } else if (
+        if (
           this.props.mode === Mode.draw &&
           !this.props.annotationsObject.splineIsClosed()
         ) {

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -294,11 +294,22 @@ class CanvasClass extends Component<Props, State> {
     // or add new point to a normal spline (Mode.draw and this.props.activeToolbox === "Spline")
     // or add TL or BR point to a rectangle spline (Mode.draw and this.props.activeToolbox === Tools.rectspline.name)
 
+    const coordinates = this.props.annotationsObject.getSplineCoordinates();
+
     if (this.isDrawing || this.dragPoint) {
       // turns out onClick still runs when releasing a drag, so we want to abort in that case:
       this.isDrawing = false;
       this.dragPoint = null;
-      return;
+
+      if (
+        !(
+          this.selectedPointIndex === coordinates.length - 1 &&
+          this.dragPoint != coordinates[coordinates.length - 1]
+        )
+      )
+        // But if the selected point is the last point in the spline, and we've not actually moved it,
+        // then don't abort onClick - the user is trying to add a point near the end of the spline.
+        return;
     }
 
     // X and Y are in CanvasSpace, convert to ImageSpace
@@ -502,7 +513,7 @@ class CanvasClass extends Component<Props, State> {
     const nearPoint = this.clickNearPoint(clickPoint, coordinates);
     if (nearPoint !== -1) {
       this.selectedPointIndex = nearPoint;
-      this.dragPoint = clickPoint;
+      this.dragPoint = coordinates[nearPoint];
     } else if (
       this.props.activeToolbox === "Magic Spline" &&
       !this.props.annotationsObject.splineIsClosed()

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -249,7 +249,7 @@ class CanvasClass extends Component<Props, State> {
   };
 
   clickNearPoint = (clickPoint: XYPoint, splineVector: XYPoint[]): number => {
-    // iterates through the points of splineVector, returns the index of the first point within distance 25 of clickPoint
+    // iterates through the points of splineVector, returns the index of the closest point within distance 25 of clickPoint
     // clickPoint and splineVector are both expected to be in image space
     // returns -1 if no point was within distance 25
 
@@ -262,6 +262,8 @@ class CanvasClass extends Component<Props, State> {
       this.state.canvasPositionAndSize
     );
 
+    let minDist = 9999999;
+    let minDistIdx = -1;
     for (let i = 0; i < splineVector.length; i += 1) {
       // transform points into canvas space so the nudge radius won't depend on zoom level:
       let point = splineVector[i];
@@ -278,10 +280,13 @@ class CanvasClass extends Component<Props, State> {
         (point.x - clickPointX) ** 2 + (point.y - clickPointY) ** 2
       );
 
-      if (distanceToPoint < 25) return i;
+      if (distanceToPoint < 25 && distanceToPoint < minDist) {
+        minDist = distanceToPoint;
+        minDistIdx = i;
+      }
     }
 
-    return -1;
+    return minDistIdx;
   };
 
   onClick = (x: number, y: number, isCTRL?: boolean): void => {

--- a/src/toolboxes/spline/Toolbar.tsx
+++ b/src/toolboxes/spline/Toolbar.tsx
@@ -57,6 +57,10 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     return true;
   };
 
+  const handleClickAway = () => {
+    return;
+  };
+
   const tools = [
     {
       name: "Spline",
@@ -129,6 +133,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     <Popper
       open={props.isOpen}
       anchorEl={props.anchorElement}
+      handleClickAway={handleClickAway}
       el={
         <ButtonGroup size="small" id="spline-toolbar" variant="text">
           {tools.map(({ icon, name, event, active }) => (

--- a/src/toolboxes/spline/Toolbar.tsx
+++ b/src/toolboxes/spline/Toolbar.tsx
@@ -57,9 +57,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     return true;
   };
 
-  const handleClickAway = () => {
-    return;
-  };
+  const handleClickAway = () => {};
 
   const tools = [
     {


### PR DESCRIPTION
## Description

Allows the user to place a new spline point close to the end of the existing spline; previously it would grab and shift the terminal point on mouse down if the mouse was close enough to the terminal point.

Also removes the nudge code, which shouldn't be in the base spline behaviour and I'm pretty sure was actually unreachable anyway.

Also fixes `clickNearPoint` so that it returns the nearest spline point to the mouse, rather than the first that's within 25 canvas pixels, preventing it from selecting a point that's not the closest to the mouse when points are tightly grouped.

Also prevents the user from adding a duplicate point on top of the final point if they click twice.

Also fixes an annoying console error complaining about a missing `onClickAway` handler in the spline toolbar.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
