### PR TITLE
feat!: Multi-image selection in Python and AI plugins

### DIFF
--- a/src/components/plugins/PluginsCard.tsx
+++ b/src/components/plugins/PluginsCard.tsx
@@ -95,7 +95,8 @@ export const PluginsCard = ({
           annotationData: annotationsObject.getAllAnnotations(),
         };
       } else {
-        data = { imageUid, collectionUid };
+        // NOTE: the plugin expects an array of image uids
+        data = { imageUids: [imageUid], collectionUid };
       }
 
       const response = await plugin.onClick(data);

--- a/src/components/plugins/interfaces.ts
+++ b/src/components/plugins/interfaces.ts
@@ -12,7 +12,7 @@ type PluginObject = { [name: string]: PluginElement[] };
 
 type PluginInput = Partial<{
   collectionUid: string;
-  imageUid: string;
+  imageUids: string[];
   imageData: ImageBitmap[][]; // image data (i.e., slicesData)
   imageFileInfo: ImageFileInfo;
   annotationData: Annotation[]; // all annotations


### PR DESCRIPTION
## Description
Change the parameter `imageUid` of type `string`, which is passed to Python and AI plugins in the request body, to `imageUids` of type `string[]`, so multiple images can be used with plugins.

Although ANNOTATE works with single images, this change is applied here for consistency with CURATE plugins.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
