### PR TITLE
feat: Add ability to pin some dialogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@emotion/styled": "^11.6.0",
         "@gliff-ai/eslint-config": "^0.2.4",
         "@gliff-ai/jest-browserstack-automate": "^6.0.0",
-        "@gliff-ai/style": "^13.0.0",
+        "@gliff-ai/style": "^13.5.0",
         "@gliff-ai/upload": "^1.2.8",
         "@mui/icons-material": "<=5.4.3",
         "@mui/material": "<=5.4.3",
@@ -59,7 +59,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
-        "@gliff-ai/style": "^13.0.0",
+        "@gliff-ai/style": "^13.5.0",
         "@gliff-ai/upload": "^1.2.8",
         "@mui/icons-material": "<=5.4.3",
         "@mui/material": "<=5.4.3",
@@ -1986,11 +1986,12 @@
       "integrity": "sha512-3l1S4fzDBR+uXkSl8PBKxj3zG4Rjgqolu/fRGoZyAqcgkDZ0AO66fi+gLDBherKuIKzJ+X7e4s1/oYzh7B4keg=="
     },
     "node_modules/@gliff-ai/style": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-13.0.1.tgz",
-      "integrity": "sha512-19V3erttECSjkOl9UwlqJkY4ctj2ab8OS9gd8AkD0oRkHbs/rXWA5T9ekS/4+SSeSTlQF66My7IUogU6Ppu+dA==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-13.5.0.tgz",
+      "integrity": "sha512-0PEdP0Iwr/GF3/2XgeBGS6T4c1Pl3pWR4tJai0e9O5SCsTvUhfd5IcB9b+VVPCgFywfQ6QcNBtDd2ryHEFpQag==",
       "dev": true,
       "dependencies": {
+        "@mui/x-data-grid": "^5.10.0",
         "csstype": "<=3.0.10",
         "react-inlinesvg": "^2.3.0"
       },
@@ -3060,15 +3061,15 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.4.4.tgz",
-      "integrity": "sha512-hfYIXEuhc2mXMGN5nUPis8beH6uE/zl3uMWJcyHX0/LN/+QxO9zhYuV6l8AsAaphHFyS/fBv0SW3Nid7jw5hKQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.8.0.tgz",
+      "integrity": "sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.17.2",
-        "@types/prop-types": "^15.7.4",
+        "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
-        "prop-types": "^15.7.2",
+        "prop-types": "^15.8.1",
         "react-is": "^17.0.2"
       },
       "engines": {
@@ -3079,7 +3080,32 @@
         "url": "https://opencollective.com/mui"
       },
       "peerDependencies": {
-        "react": "^17.0.0"
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/x-data-grid": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.11.1.tgz",
+      "integrity": "sha512-Iwm3gmHciZrYsmAOrX1W2JKo2CexgGhdG7ZXvHh1rW3OD66ITSoFilThPtrb88Eg1fZI/goDWnPr6R7JXLHc5Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.7.0",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.2.8",
+        "@mui/system": "^5.2.8",
+        "react": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3618,9 +3644,9 @@
       "dev": true
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "dev": true
     },
     "node_modules/@types/react": {
@@ -10334,6 +10360,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -13426,11 +13458,12 @@
       "integrity": "sha512-3l1S4fzDBR+uXkSl8PBKxj3zG4Rjgqolu/fRGoZyAqcgkDZ0AO66fi+gLDBherKuIKzJ+X7e4s1/oYzh7B4keg=="
     },
     "@gliff-ai/style": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-13.0.1.tgz",
-      "integrity": "sha512-19V3erttECSjkOl9UwlqJkY4ctj2ab8OS9gd8AkD0oRkHbs/rXWA5T9ekS/4+SSeSTlQF66My7IUogU6Ppu+dA==",
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/@gliff-ai/style/-/style-13.5.0.tgz",
+      "integrity": "sha512-0PEdP0Iwr/GF3/2XgeBGS6T4c1Pl3pWR4tJai0e9O5SCsTvUhfd5IcB9b+VVPCgFywfQ6QcNBtDd2ryHEFpQag==",
       "dev": true,
       "requires": {
+        "@mui/x-data-grid": "^5.10.0",
         "csstype": "<=3.0.10",
         "react-inlinesvg": "^2.3.0"
       }
@@ -14164,16 +14197,29 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.4.4.tgz",
-      "integrity": "sha512-hfYIXEuhc2mXMGN5nUPis8beH6uE/zl3uMWJcyHX0/LN/+QxO9zhYuV6l8AsAaphHFyS/fBv0SW3Nid7jw5hKQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.8.0.tgz",
+      "integrity": "sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.17.2",
-        "@types/prop-types": "^15.7.4",
+        "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
-        "prop-types": "^15.7.2",
+        "prop-types": "^15.8.1",
         "react-is": "^17.0.2"
+      }
+    },
+    "@mui/x-data-grid": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.11.1.tgz",
+      "integrity": "sha512-Iwm3gmHciZrYsmAOrX1W2JKo2CexgGhdG7ZXvHh1rW3OD66ITSoFilThPtrb88Eg1fZI/goDWnPr6R7JXLHc5Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.7.0",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.5"
       }
     },
     "@nodelib/fs.scandir": {
@@ -14615,9 +14661,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
       "dev": true
     },
     "@types/react": {
@@ -19720,6 +19766,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "reselect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
+      "integrity": "sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@emotion/styled": "^11.6.0",
     "@gliff-ai/eslint-config": "^0.2.4",
     "@gliff-ai/jest-browserstack-automate": "^6.0.0",
-    "@gliff-ai/style": "^13.0.0",
+    "@gliff-ai/style": "^13.5.0",
     "@gliff-ai/upload": "^1.2.8",
     "@mui/icons-material": "<=5.4.3",
     "@mui/material": "<=5.4.3",
@@ -66,7 +66,7 @@
   "peerDependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
-    "@gliff-ai/style": "^13.0.0",
+    "@gliff-ai/style": "^13.5.0",
     "@gliff-ai/upload": "^1.2.8",
     "@mui/icons-material": "<=5.4.3",
     "@mui/material": "<=5.4.3",

--- a/src/components/plugins/PluginsCard.tsx
+++ b/src/components/plugins/PluginsCard.tsx
@@ -29,6 +29,8 @@ interface Props {
   imageData: ImageBitmap[][];
   annotationsObject: Annotations;
   imageFileInfo: ImageFileInfo;
+  isPinned: boolean;
+  handlePin: () => void;
 }
 
 export const PluginsCard = ({
@@ -38,6 +40,8 @@ export const PluginsCard = ({
   imageData,
   imageFileInfo,
   annotationsObject,
+  isPinned,
+  handlePin,
 }: Props): ReactElement | null => {
   const [error, setError] = useState<string | null>(null);
   const [dialogContent, setDialogContent] = useState<JSX.Element | null>(null);
@@ -164,7 +168,7 @@ export const PluginsCard = ({
     return pluginElements;
   };
   return (
-    <Card title="Plugins" noPadding>
+    <Card title="Plugins" noPadding isPinned={isPinned} handlePin={handlePin}>
       <>
         <MenuList>{getPluginButtons()}</MenuList>
         <Divider

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -31,6 +31,8 @@ interface SubmenuProps {
   anchorElement: HTMLButtonElement | null;
   channelControls: ReactElement[];
   openSubmenu: () => void;
+  isChannelPinned: boolean;
+  handleChannelPin: () => void;
 }
 
 interface Props {
@@ -40,6 +42,8 @@ interface Props {
   anchorElement: HTMLButtonElement | null;
   channels: boolean[];
   toggleChannelAtIndex: (index: number) => void;
+  isChannelPinned: boolean;
+  handleChannelPin: () => void;
 }
 
 const baseSliderStyle = {
@@ -151,6 +155,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
   });
 
   const handleClickAway = () => {
+    if (buttonClicked === "Channels" && props.isChannelPinned) return;
     setButtonClicked("");
   };
 
@@ -231,7 +236,11 @@ const Submenu = (props: SubmenuProps): ReactElement => {
                 )}
                 {buttonClicked === "Channels" && props.channelControls && (
                   <>
-                    <Card title="Channel">
+                    <Card
+                      title="Channel"
+                      isPinned={props.isChannelPinned}
+                      handlePin={props.handleChannelPin}
+                    >
                       <FormControl component="fieldset">
                         <FormGroup aria-label="position">
                           {props.channelControls.map((control, i) => (
@@ -331,6 +340,8 @@ class Toolbar extends Component<Props> {
         openSubmenu={this.openSubmenu}
         anchorElement={this.props.anchorElement}
         channelControls={this.channelControls}
+        isChannelPinned={this.props.isChannelPinned}
+        handleChannelPin={this.props.handleChannelPin}
       />
     </>
   );

--- a/src/toolboxes/background/Toolbar.tsx
+++ b/src/toolboxes/background/Toolbar.tsx
@@ -75,7 +75,8 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     type: typeof submenuEvents[number];
   }
 
-  function selectBrightness() {
+  function selectBrightness(): boolean {
+    if (props.isChannelPinned) return false;
     setButtonClicked("Brightness");
     return true;
   }
@@ -87,7 +88,8 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     });
   }
 
-  function selectContrast() {
+  function selectContrast(): boolean {
+    if (props.isChannelPinned) return false;
     setButtonClicked("Contrast");
     return true;
   }
@@ -99,7 +101,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
     });
   }
 
-  function selectChannels() {
+  function selectChannels(): boolean {
     setButtonClicked("Channels");
     return true;
   }
@@ -155,7 +157,7 @@ const Submenu = (props: SubmenuProps): ReactElement => {
   });
 
   const handleClickAway = () => {
-    if (buttonClicked === "Channels" && props.isChannelPinned) return;
+    if (props.isChannelPinned) return;
     setButtonClicked("");
   };
 

--- a/src/toolboxes/labels/Submenu.tsx
+++ b/src/toolboxes/labels/Submenu.tsx
@@ -18,6 +18,7 @@ export const Submenu = (props: Props): ReactElement => (
     open={props.isOpen}
     anchorEl={props.anchorElement}
     handleClickAway={props.handleClickAway}
+    popperPlacement="right-end"
     el={
       <Card
         title="Annotation Labels"

--- a/src/toolboxes/labels/Submenu.tsx
+++ b/src/toolboxes/labels/Submenu.tsx
@@ -9,6 +9,8 @@ interface Props extends LabelsProps {
   defaultLabels: string[];
   restrictLabels: boolean;
   multiLabel: boolean;
+  isPinned: boolean;
+  handlePin: () => void;
 }
 
 export const Submenu = (props: Props): ReactElement => (
@@ -17,7 +19,11 @@ export const Submenu = (props: Props): ReactElement => (
     anchorEl={props.anchorElement}
     onClose={props.onClose}
   >
-    <Card title="Annotation Labels">
+    <Card
+      title="Annotation Labels"
+      isPinned={props.isPinned}
+      handlePin={props.handlePin}
+    >
       <Labels
         annotationsObject={props.annotationsObject}
         activeAnnotationID={props.activeAnnotationID}

--- a/src/toolboxes/labels/Submenu.tsx
+++ b/src/toolboxes/labels/Submenu.tsx
@@ -1,11 +1,11 @@
-import { ReactElement, MouseEvent } from "react";
-import { Card, MuiPopover } from "@gliff-ai/style";
+import { ReactElement } from "react";
+import { Card, Popper } from "@gliff-ai/style";
 import { Labels, Props as LabelsProps } from "./Labels";
 
 interface Props extends LabelsProps {
   isOpen: boolean;
   anchorElement: HTMLButtonElement | null;
-  onClose: (event: MouseEvent) => void;
+  handleClickAway: () => void;
   defaultLabels: string[];
   restrictLabels: boolean;
   multiLabel: boolean;
@@ -14,23 +14,24 @@ interface Props extends LabelsProps {
 }
 
 export const Submenu = (props: Props): ReactElement => (
-  <MuiPopover
+  <Popper
     open={props.isOpen}
     anchorEl={props.anchorElement}
-    onClose={props.onClose}
-  >
-    <Card
-      title="Annotation Labels"
-      isPinned={props.isPinned}
-      handlePin={props.handlePin}
-    >
-      <Labels
-        annotationsObject={props.annotationsObject}
-        activeAnnotationID={props.activeAnnotationID}
-        defaultLabels={props.defaultLabels}
-        restrictLabels={props.restrictLabels}
-        multiLabel={props.multiLabel}
-      />
-    </Card>
-  </MuiPopover>
+    handleClickAway={props.handleClickAway}
+    el={
+      <Card
+        title="Annotation Labels"
+        isPinned={props.isPinned}
+        handlePin={props.handlePin}
+      >
+        <Labels
+          annotationsObject={props.annotationsObject}
+          activeAnnotationID={props.activeAnnotationID}
+          defaultLabels={props.defaultLabels}
+          restrictLabels={props.restrictLabels}
+          multiLabel={props.multiLabel}
+        />
+      </Card>
+    }
+  />
 );

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -94,6 +94,7 @@ interface State {
     scale: number;
   };
   activeToolbox?: Toolbox; // FIXME
+  isToolPinned?: { [tool: string]: boolean };
   displayedImage?: ImageBitmap;
   activeAnnotationID: number;
   viewportPositionAndSize: Required<PositionAndSize>;
@@ -241,6 +242,11 @@ class UserInterface extends Component<Props, State> {
       activeToolbox: Toolboxes.paintbrush,
       mode: Mode.draw,
       canvasContainerColour: [255, 255, 255, 1],
+      isToolPinned: {
+        "Annotation Label": false,
+        Plugins: false,
+        Channels: false,
+      },
     };
 
     this.imageFileInfo = this.props.imageFileInfo || null;
@@ -584,6 +590,15 @@ class UserInterface extends Component<Props, State> {
     });
   };
 
+  setIsToolPinned = (tool: string) => (): void => {
+    if (this.state.isToolPinned[tool] === undefined) return;
+    this.setState((prevState) => {
+      const newIsPinned = { ...prevState.isToolPinned };
+      newIsPinned[tool] = !newIsPinned[tool];
+      return { isToolPinned: newIsPinned };
+    });
+  };
+
   reuseEmptyAnnotation = (): void => {
     /* If the active annotation object is empty, change the value of toolbox
     to match the active tool. */
@@ -634,7 +649,8 @@ class UserInterface extends Component<Props, State> {
     }, this.mixChannels);
   };
 
-  handleClose = (): void => {
+  handleClose = (isDisabled?: boolean) => (): void => {
+    if (isDisabled) return;
     this.setState({ activeSubmenuAnchor: null });
   };
 
@@ -862,19 +878,23 @@ class UserInterface extends Component<Props, State> {
               this.refBtnsPopovers["Annotation Label"]
             }
             anchorElement={this.state.activeSubmenuAnchor}
-            onClose={this.handleClose}
+            onClose={this.handleClose(
+              this.state.isToolPinned["Annotation Label"]
+            )}
             annotationsObject={this.annotationsObject}
             activeAnnotationID={this.state.activeAnnotationID}
             defaultLabels={this.props.defaultLabels}
             restrictLabels={this.props.restrictLabels}
             multiLabel={this.props.multiLabel}
+            isPinned={this.state.isToolPinned["Annotation Label"]}
+            handlePin={this.setIsToolPinned("Annotation Label")}
           />
           <MuiPopover
             open={
               this.state.activeSubmenuAnchor === this.refBtnsPopovers.Plugins
             }
             anchorEl={this.state.activeSubmenuAnchor}
-            onClose={this.handleClose}
+            onClose={this.handleClose(this.state.isToolPinned.Plugins)}
           >
             <PluginsCard
               plugins={this.props.plugins}
@@ -885,6 +905,8 @@ class UserInterface extends Component<Props, State> {
               imageFileInfo={this.props.imageFileInfo}
               annotationsObject={this.annotationsObject}
               saveMetadataCallback={this.props.saveMetadataCallback}
+              isPinned={this.state.isToolPinned.Plugins}
+              handlePin={this.setIsToolPinned("Plugins")}
             />
           </MuiPopover>
         </ButtonGroup>
@@ -914,22 +936,28 @@ class UserInterface extends Component<Props, State> {
             anchorElement={this.state.activeSubmenuAnchor}
             channels={this.state.channels}
             toggleChannelAtIndex={this.toggleChannelAtIndex}
+            isChannelPinned={this.state.isToolPinned.Channels}
+            handleChannelPin={this.setIsToolPinned("Channels")}
           />
         </ButtonGroup>
 
-        <LabelsSubmenu
+        {/* <LabelsSubmenu
           isOpen={
             this.state.activeSubmenuAnchor ===
             this.refBtnsPopovers["Annotation Label"]
           }
           anchorElement={this.state.activeSubmenuAnchor}
-          onClose={this.handleClose}
+          onClose={this.handleClose(
+            this.state.isToolPinned["Annotation Label"]
+          )}
           annotationsObject={this.annotationsObject}
           activeAnnotationID={this.state.activeAnnotationID}
           defaultLabels={this.props.defaultLabels}
           restrictLabels={this.props.restrictLabels}
           multiLabel={this.props.multiLabel}
-        />
+          isPinned={this.state.isToolPinned["Annotation Label"]}
+          handlePin={this.setIsToolPinned("Annotation Label")}
+        /> */}
       </div>
     );
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -22,7 +22,7 @@ import {
   icons,
   generateClassName,
   WarningSnackbar,
-  MuiPopover,
+  Popper,
 } from "@gliff-ai/style";
 import { Annotations } from "@/annotation";
 import { PositionAndSize } from "@/annotation/interfaces";
@@ -590,11 +590,11 @@ class UserInterface extends Component<Props, State> {
     });
   };
 
-  setIsToolPinned = (tool: string) => (): void => {
+  setIsToolPinned = (tool: string, value?: boolean) => (): void => {
     if (this.state.isToolPinned[tool] === undefined) return;
     this.setState((prevState) => {
       const newIsPinned = { ...prevState.isToolPinned };
-      newIsPinned[tool] = !newIsPinned[tool];
+      newIsPinned[tool] = value !== undefined ? value : !newIsPinned[tool];
       return { isToolPinned: newIsPinned };
     });
   };
@@ -649,9 +649,8 @@ class UserInterface extends Component<Props, State> {
     }, this.mixChannels);
   };
 
-  handleClose = (isDisabled?: boolean) => (): void => {
-    if (isDisabled) return;
-    this.setState({ activeSubmenuAnchor: null });
+  handleClose = (): void => {
+    this.setState({ activeSubmenuAnchor: null, buttonClicked: "" });
   };
 
   handleOpen =
@@ -688,12 +687,10 @@ class UserInterface extends Component<Props, State> {
 
   selectAnnotationLabel = (): void => {
     this.handleOpen()(this.refBtnsPopovers["Annotation Label"]);
-    this.setButtonClicked("Annotation Label");
   };
 
   selectPlugins = (): void => {
     this.handleOpen()(this.refBtnsPopovers.Plugins);
-    this.setButtonClicked("Plugins");
   };
 
   saveAnnotations = (): void => {
@@ -732,6 +729,15 @@ class UserInterface extends Component<Props, State> {
 
   setCanvasContainerColourCallback = (canvasContainerColour: number[]): void =>
     this.setState({ canvasContainerColour });
+
+  handleClickAway = (tool: string) => (): void => {
+    if (!this.state.isToolPinned[tool] && this.state.buttonClicked === tool) {
+      this.handleClose();
+      this.setIsToolPinned(tool, false); // reset default
+    } else if (this.state.buttonClicked !== tool) {
+      this.setButtonClicked(tool); // set button clicked at first open
+    }
+  };
 
   render = (): ReactNode => {
     const { classes, showAppBar, saveAnnotationsCallback } = this.props;
@@ -878,9 +884,7 @@ class UserInterface extends Component<Props, State> {
               this.refBtnsPopovers["Annotation Label"]
             }
             anchorElement={this.state.activeSubmenuAnchor}
-            onClose={this.handleClose(
-              this.state.isToolPinned["Annotation Label"]
-            )}
+            handleClickAway={this.handleClickAway("Annotation Label")}
             annotationsObject={this.annotationsObject}
             activeAnnotationID={this.state.activeAnnotationID}
             defaultLabels={this.props.defaultLabels}
@@ -889,28 +893,29 @@ class UserInterface extends Component<Props, State> {
             isPinned={this.state.isToolPinned["Annotation Label"]}
             handlePin={this.setIsToolPinned("Annotation Label")}
           />
-          <MuiPopover
+          <Popper
             open={
               this.state.activeSubmenuAnchor === this.refBtnsPopovers.Plugins
             }
             anchorEl={this.state.activeSubmenuAnchor}
-            onClose={this.handleClose(this.state.isToolPinned.Plugins)}
-          >
-            <PluginsCard
-              plugins={this.props.plugins}
-              launchPluginSettingsCallback={
-                this.props.launchPluginSettingsCallback
-              }
-              imageData={this.slicesData}
-              imageFileInfo={this.props.imageFileInfo}
-              annotationsObject={this.annotationsObject}
-              saveMetadataCallback={this.props.saveMetadataCallback}
-              isPinned={this.state.isToolPinned.Plugins}
-              handlePin={this.setIsToolPinned("Plugins")}
-            />
-          </MuiPopover>
+            popperPlacement="right-end"
+            handleClickAway={this.handleClickAway("Plugins")}
+            el={
+              <PluginsCard
+                plugins={this.props.plugins}
+                launchPluginSettingsCallback={
+                  this.props.launchPluginSettingsCallback
+                }
+                imageData={this.slicesData}
+                imageFileInfo={this.props.imageFileInfo}
+                annotationsObject={this.annotationsObject}
+                saveMetadataCallback={this.props.saveMetadataCallback}
+                isPinned={this.state.isToolPinned.Plugins}
+                handlePin={this.setIsToolPinned("Plugins")}
+              />
+            }
+          />
         </ButtonGroup>
-
         <ButtonGroup>
           <PaintbrushToolbar
             active={this.state.activeToolbox === "paintbrush"}
@@ -940,24 +945,6 @@ class UserInterface extends Component<Props, State> {
             handleChannelPin={this.setIsToolPinned("Channels")}
           />
         </ButtonGroup>
-
-        {/* <LabelsSubmenu
-          isOpen={
-            this.state.activeSubmenuAnchor ===
-            this.refBtnsPopovers["Annotation Label"]
-          }
-          anchorElement={this.state.activeSubmenuAnchor}
-          onClose={this.handleClose(
-            this.state.isToolPinned["Annotation Label"]
-          )}
-          annotationsObject={this.annotationsObject}
-          activeAnnotationID={this.state.activeAnnotationID}
-          defaultLabels={this.props.defaultLabels}
-          restrictLabels={this.props.restrictLabels}
-          multiLabel={this.props.multiLabel}
-          isPinned={this.state.isToolPinned["Annotation Label"]}
-          handlePin={this.setIsToolPinned("Annotation Label")}
-        /> */}
       </div>
     );
 

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -102,7 +102,7 @@ interface State {
   redrawEverything: number;
   sliceIndex: number;
   channels: boolean[];
-  activeSubmenuAnchor: HTMLButtonElement | null; // A HTML element. It specifies which button has its submenu open, and serves as anchorEl for that submenu: https://material-ui.com/api/menu/#props
+  activeSubmenuAnchor: { [tool: string]: HTMLButtonElement | null }; // A HTML element. It specifies which button has its submenu open, and serves as anchorEl for that submenu: https://material-ui.com/api/menu/#props
   buttonClicked: string;
   mode: Mode;
   canvasContainerColour: number[];
@@ -237,7 +237,7 @@ class UserInterface extends Component<Props, State> {
       channels: [true],
       displayedImage: this.slicesData ? this.slicesData[0][0] : null,
       redrawEverything: 0,
-      activeSubmenuAnchor: null,
+      activeSubmenuAnchor: {},
       buttonClicked: null,
       activeToolbox: Toolboxes.paintbrush,
       mode: Mode.draw,
@@ -245,7 +245,7 @@ class UserInterface extends Component<Props, State> {
       isToolPinned: {
         "Annotation Label": false,
         Plugins: false,
-        Channels: false,
+        Background: false,
       },
     };
 
@@ -649,19 +649,40 @@ class UserInterface extends Component<Props, State> {
     }, this.mixChannels);
   };
 
-  handleClose = (): void => {
-    this.setState({ activeSubmenuAnchor: null, buttonClicked: "" });
+  setActiveSubmenuAnchor = (
+    tool: string,
+    value: HTMLButtonElement | null
+  ): void => {
+    this.setState((prevState) => {
+      const activeSubmenuAnchor = { ...prevState.activeSubmenuAnchor };
+      activeSubmenuAnchor[tool] = value; // set new anchor
+
+      // set anchor for all other non-pinned dialogs to null
+      for (const t of Object.keys(activeSubmenuAnchor)) {
+        if (t !== tool && !prevState.isToolPinned[t]) {
+          activeSubmenuAnchor[t] = null;
+        }
+      }
+      return { activeSubmenuAnchor };
+    });
+  };
+
+  handleClose = (tool: string): void => {
+    this.setActiveSubmenuAnchor(tool, null);
+    this.setState({ buttonClicked: "" });
   };
 
   handleOpen =
+    (tool: string) =>
     (event?: React.MouseEvent) =>
     (activeSubmenuAnchor?: HTMLButtonElement): void => {
       if (activeSubmenuAnchor !== undefined) {
-        this.setState({ activeSubmenuAnchor });
+        this.setActiveSubmenuAnchor(tool, activeSubmenuAnchor);
       } else if (event) {
-        this.setState({
-          activeSubmenuAnchor: event.currentTarget as HTMLButtonElement,
-        });
+        this.setActiveSubmenuAnchor(
+          tool,
+          event.currentTarget as HTMLButtonElement
+        );
       }
     };
 
@@ -671,26 +692,28 @@ class UserInterface extends Component<Props, State> {
   // Functions of type select<ToolTip.name>, added for use in keybindings and OnClick events
   // TODO: find a way to pass parameters in keybindings and get rid of code duplication
   selectContrast = (): void => {
-    this.handleOpen()(this.refBtnsPopovers.Contrast);
+    this.handleOpen("Contrast")()(this.refBtnsPopovers.Contrast);
     this.setButtonClicked("Contrast");
   };
 
   selectBrightness = (): void => {
-    this.handleOpen()(this.refBtnsPopovers.Brightness);
+    this.handleOpen("Brightness")()(this.refBtnsPopovers.Brightness);
     this.setButtonClicked("Brightness");
   };
 
   selectChannels = (): void => {
-    this.handleOpen()(this.refBtnsPopovers.Channels);
+    this.handleOpen("Channels")()(this.refBtnsPopovers.Channels);
     this.setButtonClicked("Channels");
   };
 
   selectAnnotationLabel = (): void => {
-    this.handleOpen()(this.refBtnsPopovers["Annotation Label"]);
+    this.handleOpen("Annotation Label")()(
+      this.refBtnsPopovers["Annotation Label"]
+    );
   };
 
   selectPlugins = (): void => {
-    this.handleOpen()(this.refBtnsPopovers.Plugins);
+    this.handleOpen("Plugins")()(this.refBtnsPopovers.Plugins);
   };
 
   saveAnnotations = (): void => {
@@ -713,7 +736,7 @@ class UserInterface extends Component<Props, State> {
   isTyping = (): boolean =>
     // Added to prevent single-key shortcuts that are also valid text input
     // to get triggered during text input.
-    this.refBtnsPopovers["Annotation Label"] === this.state.activeSubmenuAnchor;
+    this.state.activeSubmenuAnchor["Annotation Label"] !== null;
 
   setModeCallback = (mode: Mode): void => {
     this.setState(() => ({ mode, buttonClicked: null }));
@@ -731,11 +754,14 @@ class UserInterface extends Component<Props, State> {
     this.setState({ canvasContainerColour });
 
   handleClickAway = (tool: string) => (): void => {
-    if (!this.state.isToolPinned[tool] && this.state.buttonClicked === tool) {
-      this.handleClose();
-      this.setIsToolPinned(tool, false); // reset default
-    } else if (this.state.buttonClicked !== tool) {
-      this.setButtonClicked(tool); // set button clicked at first open
+    console.log(this.state.activeSubmenuAnchor[tool]);
+    if (!this.state.isToolPinned[tool]) {
+      if (this.state.buttonClicked === tool) {
+        this.handleClose(tool);
+        this.setIsToolPinned(tool, false); // reset default
+      } else if (this.state.buttonClicked !== tool) {
+        this.setButtonClicked(tool); // set button clicked at first open
+      }
     }
   };
 
@@ -814,9 +840,7 @@ class UserInterface extends Component<Props, State> {
         name: "Annotation Label",
         icon: icons.annotationLabel,
         event: "selectAnnotationLabel",
-        active: () =>
-          this.state.activeSubmenuAnchor ===
-          this.refBtnsPopovers["Annotation Label"],
+        active: () => !!this.state.activeSubmenuAnchor["Annotation Label"],
         enabled: () => true,
       },
       {
@@ -837,8 +861,7 @@ class UserInterface extends Component<Props, State> {
         name: "Plugins",
         icon: icons.plugins,
         event: "selectPlugins",
-        active: () =>
-          this.state.activeSubmenuAnchor === this.refBtnsPopovers.Plugins,
+        active: () => !!this.state.activeSubmenuAnchor.Plugins,
         enabled: () => !!this.props?.plugins,
       },
     ] as const;
@@ -879,11 +902,8 @@ class UserInterface extends Component<Props, State> {
             />
           )}
           <LabelsSubmenu
-            isOpen={
-              this.state.activeSubmenuAnchor ===
-              this.refBtnsPopovers["Annotation Label"]
-            }
-            anchorElement={this.state.activeSubmenuAnchor}
+            isOpen={!!this.state.activeSubmenuAnchor["Annotation Label"]}
+            anchorElement={this.state.activeSubmenuAnchor["Annotation Label"]}
             handleClickAway={this.handleClickAway("Annotation Label")}
             annotationsObject={this.annotationsObject}
             activeAnnotationID={this.state.activeAnnotationID}
@@ -894,10 +914,8 @@ class UserInterface extends Component<Props, State> {
             handlePin={this.setIsToolPinned("Annotation Label")}
           />
           <Popper
-            open={
-              this.state.activeSubmenuAnchor === this.refBtnsPopovers.Plugins
-            }
-            anchorEl={this.state.activeSubmenuAnchor}
+            open={!!this.state.activeSubmenuAnchor.Plugins}
+            anchorEl={this.state.activeSubmenuAnchor.Plugins}
             popperPlacement="right-end"
             handleClickAway={this.handleClickAway("Plugins")}
             el={
@@ -920,29 +938,29 @@ class UserInterface extends Component<Props, State> {
           <PaintbrushToolbar
             active={this.state.activeToolbox === "paintbrush"}
             activateToolbox={this.activateToolbox}
-            handleOpen={this.handleOpen}
-            anchorElement={this.state.activeSubmenuAnchor}
+            handleOpen={this.handleOpen("Paintbrush")}
+            anchorElement={this.state.activeSubmenuAnchor.Paintbrush}
             is3D={this.slicesData?.length > 1}
           />
           <SplineToolbar
             active={this.state.activeToolbox === "spline"}
             activateToolbox={this.activateToolbox}
-            handleOpen={this.handleOpen}
-            anchorElement={this.state.activeSubmenuAnchor}
+            handleOpen={this.handleOpen("Spline")}
+            anchorElement={this.state.activeSubmenuAnchor.Spline}
           />
 
           <BoundingBoxToolbar
             active={this.state.activeToolbox === "boundingBox"}
             activateToolbox={this.activateToolbox}
-            handleOpen={this.handleOpen}
+            handleOpen={this.handleOpen("BoundingBox")}
           />
           <BackgroundToolbar
-            handleOpen={this.handleOpen}
-            anchorElement={this.state.activeSubmenuAnchor}
+            handleOpen={this.handleOpen("Background")}
+            anchorElement={this.state.activeSubmenuAnchor.Background}
             channels={this.state.channels}
             toggleChannelAtIndex={this.toggleChannelAtIndex}
-            isChannelPinned={this.state.isToolPinned.Channels}
-            handleChannelPin={this.setIsToolPinned("Channels")}
+            isChannelPinned={this.state.isToolPinned.Background}
+            handleChannelPin={this.setIsToolPinned("Background")}
           />
         </ButtonGroup>
       </div>


### PR DESCRIPTION
## Description
- Add ability to pin "Annotation Lables", "Plugins" and "Channels" dialogs.

Question for @joshuajames-smith: only one dialog can be pinned open at a time, so a pinned dialog closes when a new one is opened. Do we want more than one dialog open at a time? 

addresses gliff-ai/annotate#709
relies on gliff-ai/style#201

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
