### PR TITLE
fix: delete bezier

### DIFF
--- a/src/annotation/index.ts
+++ b/src/annotation/index.ts
@@ -89,12 +89,16 @@ export class Annotations {
 
   @log
   deleteActiveAnnotation(): void {
+    const wasBezier = this.splineIsBezier();
     this.data.splice(this.activeAnnotationID, 1);
     if (this.activeAnnotationID >= this.data.length && this.data.length > 0) {
       this.activeAnnotationID = this.data.length - 1; // necessary if we delete the one on the end
     }
     if (this.data.length === 0) {
       this.addAnnotation(Toolboxes.paintbrush); // re-create a new empty annotation if we delete the last one (toolbox will be re-assigned by reuseEmptyAnnotation if necessary)
+      if (wasBezier) {
+        this.setSplineBezier(true);
+      }
     }
     this.initUndoRedo();
   }

--- a/src/toolboxes/spline/Canvas.tsx
+++ b/src/toolboxes/spline/Canvas.tsx
@@ -133,10 +133,7 @@ class CanvasClass extends PureComponent<Props, State> {
           splineVector[this.selectedPointIndex + 1].x += translation.x;
           splineVector[this.selectedPointIndex + 1].y += translation.y;
         }
-        if (
-          this.selectedPointIndex === 0 &&
-          this.props.annotationsObject.splineIsClosed()
-        ) {
+        if (this.selectedPointIndex === 0 && spline.isClosed) {
           splineVector[splineVector.length - 1].x += translation.x;
           splineVector[splineVector.length - 1].y += translation.y;
         }
@@ -184,10 +181,7 @@ class CanvasClass extends PureComponent<Props, State> {
           );
           i += 3;
         }
-        if (
-          this.props.annotationsObject.splineIsClosed() &&
-          i + 2 === splineVector.length
-        ) {
+        if (spline.isClosed && i + 2 === splineVector.length) {
           // draw final arc to close the curve:
           context.bezierCurveTo(
             splineVector[i].x,
@@ -232,10 +226,7 @@ class CanvasClass extends PureComponent<Props, State> {
           }
           i += 3;
         }
-        if (
-          this.props.annotationsObject.splineIsClosed() &&
-          i === splineVector.length
-        ) {
+        if (spline.isClosed && i === splineVector.length) {
           // draw line connecting first point with its "first" control point:
           context.moveTo(splineVector[0].x, splineVector[0].y);
           context.lineTo(

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -736,7 +736,7 @@ class UserInterface extends Component<Props, State> {
   isTyping = (): boolean =>
     // Added to prevent single-key shortcuts that are also valid text input
     // to get triggered during text input.
-    this.state.activeSubmenuAnchor["Annotation Label"] !== null;
+    !!this.state.activeSubmenuAnchor["Annotation Label"];
 
   setModeCallback = (mode: Mode): void => {
     this.setState(() => ({ mode, buttonClicked: null }));


### PR DESCRIPTION
## Description

Three bug fixes:
1. Fixed `isTyping()` so it's no longer constantly returns true (was breaking all keyboard shortcuts)
2. When deleting the last annotation, a new annotation is automatically created. We automatically set the toolbox of this new annotation to be the same as the one that was deleted so it doesn't auto-change to paintbrush by default, but we needed to set `spline.isBezier` to `false` when the deleted spline was Bezier, otherwise spline store continues to say it is Bezier and the desync between annotation state and spline store breaks the toolbar logic (remember we can't access spline store in ui because it's a class component).
3. Was rendering all Bezier splines as open or closed depending on the state of the active annotation, now they're rendered correctly.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
