### PR TITLE
offline detection and navigation catches

### DIFF
--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -22,6 +22,8 @@ import {
   generateClassName,
   WarningSnackbar,
   Popper,
+  AdvancedDialog,
+  Button,
 } from "@gliff-ai/style";
 import { Annotations } from "@/annotation";
 import { PositionAndSize } from "@/annotation/interfaces";
@@ -195,6 +197,18 @@ const styles = {
   },
 };
 
+const connectionError = {
+  // maxHeight: "200px",
+};
+const offlineButtonsGrid = {
+  display: "flex",
+  justifyContent: "space-between",
+};
+const warningContainer = {
+  marginTop: "5px",
+  marginBottom: "20px",
+};
+
 interface Props extends WithStyles<typeof styles> {
   slicesData?: ImageBitmap[][] | null;
   imageFileInfo?: ImageFileInfo;
@@ -205,6 +219,7 @@ interface Props extends WithStyles<typeof styles> {
   // setIsLoading is used, but in progress.tsx
   // eslint-disable-next-line react/no-unused-prop-types
   setIsLoading?: (isLoading: boolean) => void;
+  offline?: boolean;
   userAccess?: UserAccess;
   plugins?: PluginObject | null;
   launchPluginSettingsCallback?: (() => void) | null;
@@ -223,6 +238,7 @@ class UserInterface extends Component<Props, State> {
     saveAnnotationsCallback: null,
     showAppBar: true,
     setIsLoading: null,
+    offline: false,
     slicesData: null,
     imageFileInfo: undefined,
     userAccess: UserAccess.Collaborator,
@@ -1314,6 +1330,25 @@ class UserInterface extends Component<Props, State> {
                 !this.props.readonly
               }
             />
+            <AdvancedDialog
+              sx={connectionError}
+              open={this.props.offline || true}
+              title="Connection Error"
+              warningDialog={true}
+            >
+              <Container sx={warningContainer}>
+                Please check your connection. Your unsaved changes will be lost
+                if we are unable to establish a connection.
+              </Container>
+              <Grid sx={offlineButtonsGrid}>
+                <Button color="secondary" variant="outlined">
+                  Exit without Saving
+                </Button>
+                <Button color="secondary" variant="contained">
+                  Retry Saving
+                </Button>
+              </Grid>
+            </AdvancedDialog>
           </ThemeProvider>
         </StyledEngineProvider>
       </StylesProvider>


### PR DESCRIPTION
## Description

Introduced a warning card when the user tries to save when they are offline in order to inform them to retry saving or continue without saving.
This relates to gliff-ai/annotate#706 and will help users to avoid losing progress.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [x] I have read the gliff.ai Contribution Guide.
- [x] I have requested to **pull a branch** and not from main.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
